### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism Fortran Track
 
-[![Build Status](https://travis-ci.org/exercism/xfortran.svg?branch=master)](https://travis-ci.org/exercism/xfortran)
+[![Build Status](https://travis-ci.org/exercism/fortran.svg?branch=master)](https://travis-ci.org/exercism/fortran)
 
 Exercism exercises in Fortran.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "fortran",
   "language": "Fortran",
-  "repository": "https://github.com/exercism/xfortran",
+  "repository": "https://github.com/exercism/fortran",
   "active": false,
   "test_pattern": ".*\\.fun",
   "solution_pattern": "example.f90",


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1