### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,9 @@
+module hello_world
+contains
+  function hello()
+    character(12) :: hello
+    hello = 'Hello World'
+
+  end function hello
+
+end module hello_world


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.


See https://github.com/exercism/meta/issues/89