### PR TITLE
Remove system level style ignores from project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-*.swp
-.DS_Store
 bin/configlet
 bin/configlet.exe


### PR DESCRIPTION
Editor and operating system files aren't something we should be worried
about.  Refer folks to their "global" gitignore file for these items
instead.