### PR TITLE
Travis build for cmake files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 ---
 language: c
 
-before_install:
-  - sudo apt-get install gfortran
-  - sudo apt-get install ruby-full
-
 install:
-  - sudo gem install funit
+  - sudo apt-get -y install gfortran cmake
 
 script:
-  - make test
   - bin/fetch-configlet
   - bin/configlet lint .
+  - mkdir Debug
+  - cd Debug
+  - cmake -G "Unix Makefiles" ..
+  - make
+  - ctest -V
 
 sudo: required
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(exercism Fortran)
+include(CTest)
+
+set(EXERCISM_RUN_ALL_TESTS 1)
+
+function(travis_fixup exercise)
+  string(REPLACE "-" "_" file ${exercise})
+  set(subdir ${CMAKE_CURRENT_SOURCE_DIR}/exercises/${exercise})
+  if(EXISTS ${subdir}/example.f90)
+    configure_file( ${subdir}/example.f90 ${subdir}/${file}_build_all.f90)
+  endif()
+endfunction()
+
+add_subdirectory(testlib)
+include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
+
+file(GLOB exercise_list ${CMAKE_CURRENT_SOURCE_DIR}/exercises/*/CMakeLists.txt)
+
+foreach(exercise_cmake ${exercise_list})
+  get_filename_component(exercise_dir ${exercise_cmake} DIRECTORY)
+  get_filename_component(exercise ${exercise_dir} NAME)
+  travis_fixup(${exercise})
+  add_subdirectory(${exercise_dir})
+endforeach()
+
+
+

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "active": false,
   "blurb": "",
   "solution_pattern": "example.f90",
-  "test_pattern": ".*\\.fun",
+  "test_pattern": ".*\\_test.f90",
   "exercises": [
     {
       "slug": "hello-world",

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -10,29 +10,28 @@ project(${exercise} Fortran)
 # set debug build default
 set(CMAKE_BIULD_TYPE Debug)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
-    set(exercise_f90 ${file}.f90)
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
+    set(exercise_f90 ${file}_build_all.f90)
 else()
-    set(exercise_f90 "")
+    # if building in exercise folder add testlib
+    add_subdirectory(testlib)
+    include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
+    if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+      file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
+    endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
+        set(exercise_f90 ${file}.f90)
+    endif()
 endif()
+
 
 # Build executable from sources and headers
 add_executable(${exercise} ${exercise_f90} ${file}_test.f90  )
-
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib) 
-	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
-endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib) 
-
-add_subdirectory(testlib)
-include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
 
 target_link_libraries(${exercise} TesterMain)
 

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -10,29 +10,28 @@ project(${exercise} Fortran)
 # set debug build default
 set(CMAKE_BIULD_TYPE Debug)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
-    set(exercise_f90 ${file}.f90)
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
+    set(exercise_f90 ${file}_build_all.f90)
 else()
-    set(exercise_f90 "")
+    # if building in exercise folder add testlib
+    add_subdirectory(testlib)
+    include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
+    if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+      file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
+    endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
+        set(exercise_f90 ${file}.f90)
+    endif()
 endif()
+
 
 # Build executable from sources and headers
 add_executable(${exercise} ${exercise_f90} ${file}_test.f90  )
-
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib) 
-	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
-endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib) 
-
-add_subdirectory(testlib)
-include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
 
 target_link_libraries(${exercise} TesterMain)
 

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -10,29 +10,28 @@ project(${exercise} Fortran)
 # set debug build default
 set(CMAKE_BIULD_TYPE Debug)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
-    set(exercise_f90 ${file}.f90)
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
+    set(exercise_f90 ${file}_build_all.f90)
 else()
-    set(exercise_f90 "")
+    # if building in exercise folder add testlib
+    add_subdirectory(testlib)
+    include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
+    if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+      file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
+    endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
+        set(exercise_f90 ${file}.f90)
+    endif()
 endif()
 
+
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.f90 ${exercise_f90} )
-
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib) 
-	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
-endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/testlib) 
-
-add_subdirectory(testlib)
-include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
+add_executable(${exercise} ${exercise_f90} ${file}_test.f90  )
 
 target_link_libraries(${exercise} TesterMain)
 


### PR DESCRIPTION
Changed .travis.yml to build with cmake files and modified
CMakeLists.txt accordingly. Travis or maintainer can build all examples
in root of git repository with

$ mkdir Debug
$ cd Debug
$ cmake ..
$ make
$ ctest

The way it works is EXERCISM_RUN_ALL_TESTS is set and "example.f90" is
copied to <exercise_name>_build_all.f90 and then built.

Students or single build is still supported, by going in to the exercise
directory and execution above build instructions.