### PR TITLE
Activate fortran compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,18 @@ include(CTest)
 
 set(EXERCISM_RUN_ALL_TESTS 1)
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 function(travis_fixup exercise)
   string(REPLACE "-" "_" file ${exercise})
   set(subdir ${CMAKE_CURRENT_SOURCE_DIR}/exercises/${exercise})

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_BIULD_TYPE Debug)
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    set (CMAKE_Fortran_FLAGS "/warn:all")
+  else()
+    set (CMAKE_Fortran_FLAGS "-warn all")
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic")
+endif()
+
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)


### PR DESCRIPTION
Inspired by https://github.com/exercism/fortran/issues/2 I have
activated warnings for GFortran and Intel Fortran for all exercises.
Tested on linux (Gfortran) and on Windows (Intel and GFortran).