### PR TITLE
Rename directory to build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ bin/configlet
 bin/configlet.exe
 
 # make and testing artifacts
-Debug
+build
 exercises/*/*_build_all.f90

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
 script:
   - bin/fetch-configlet
   - bin/configlet lint .
-  - mkdir Debug
-  - cd Debug
+  - mkdir build
+  - cd build
   - cmake -G "Unix Makefiles" ..
   - make
   - ctest -V

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Assuming that you have CMake and Fortran running you should be able to run the f
 ### Linux and MacOS
 
 ```bash
-mkdir Debug
-cd Debug
-cmake -DCMAKE_BUILD_TYPE="Debug" ..
+mkdir build
+cd build
+cmake ..
 make
 ctest -V
 ```
@@ -23,9 +23,9 @@ ctest -V
 ### Windows
 
 ```Batchfile
-mkdir Debug
-cd Debug
-cmake -DCMAKE_BUILD_TYPE="Debug" -G"NMake Makefiles" ..
+mkdir build
+cd build
+cmake -G"NMake Makefiles" ..
 nmake
 ctest -V
 ```

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -33,8 +33,8 @@ Wrote : exercises/bob/bob_test.f90
 $ cp config/CMakeLists.txt exercises/bob/.
 $ cd exercises/bob
 $ touch bob.f90
-$ mkdir Debug
-$ cd Debug
+$ mkdir build
+$ cd build
 $ cmake ..
 $ make
 $ ctest -V

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -31,11 +31,11 @@ contains
 end module {{ .Spec.SnakeCaseName }}
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `{{ .Spec.SnakeCaseName -}}_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -120,14 +120,14 @@ correctly. Also, on Windows you should specify the cmake generator
 `NMake` for a command line build, eg.
 
 ```Batchfile
-mkdir Debug
-cd Debug
+mkdir build
+cd build
 cmake -G"NMake Makefiles" ..
 NMake
 ctest -V
 ```
 
-The commands above will create a Debug directory (not necessary, but
+The commands above will create a `build` directory (not necessary, but
 good practice) and build (NMake) the executables and test them (ctest).
 
 For other versions of Intel Fortran you want to search your installation
@@ -137,8 +137,8 @@ which options you have. On Linux or MacOS the commands would be:
 
 ```bash
 . /opt/intel/parallel_studio_xe_2016.1.056/compilers_and_libraries_2016/linux/bin/ifortvars.sh intel64
-mkdir Debug
-cd Debug
+mkdir build
+cd build
 cmake ..
 make
 ctest -V

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -34,8 +34,8 @@ Wrote : exercises/bob/bob_test.f90
 $ cp config/CMakeLists.txt exercises/bob/.
 $ cd exercises/bob
 $ touch bob.f90
-$ mkdir Debug
-$ cd Debug
+$ mkdir build
+$ cd build
 $ cmake ..
 $ make
 $ ctest -V

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -50,7 +50,7 @@ Using this recipe, CMake can generate a suitable project for your environment
 by running `cmake -G` with a suitable generator and the location of the
 directory for the exercise.  CMake will generate a build script appropriate
 for your operating system.  To keep those generated files separate from
-your exercise source code, it is common to create a directory called `Debug` or `build`
+your exercise source code, it is common to create a directory called `build`
 to hold these generated build files, as well as the compiled code.
 
 This will keep your exercise folder uncluttered and tidy.
@@ -79,8 +79,8 @@ Assuming the current exercise is `bob` and we're in the exercise folder:
 
 ```
 $ touch bob.f90
-$ mkdir Debug
-$ cd Debug
+$ mkdir build
+$ cd build
 $ cmake -G "Unix Makefiles" ..
 $ make
 ```

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -42,11 +42,11 @@ contains
 end module bob
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `bob_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/exercises/bob/bob_test.f90
+++ b/exercises/bob/bob_test.f90
@@ -7,9 +7,9 @@
 !
 ! If the file does not exist create it.
 !
-! To build your program first create a build directory, eg. Debug and change into it
-! > mkdir Debug
-! > cd Debug
+! To build your program first create a build directory, eg. build and change into it
+! > mkdir build
+! > cd build
 ! Now, to configure the build you run
 ! > cmake ..
 ! Which creates the build files (Makefiles etc.) needed to build and test your program.

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -43,11 +43,11 @@ contains
 end module difference_of_squares
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `difference_of_squares_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -50,11 +50,11 @@ contains
 end module hamming
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `hamming_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -41,11 +41,11 @@ contains
 end module hello_world
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `hello_world_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/exercises/hello-world/hello_world_test.f90
+++ b/exercises/hello-world/hello_world_test.f90
@@ -6,9 +6,9 @@
 !
 ! If the file does not exist create it.
 !
-! To build your program first create a build directory, eg. Debug and change into it
-! > mkdir Debug
-! > cd Debug
+! To build your program first create a build directory, eg. build and change into it
+! > mkdir build
+! > cd build
 ! Now, to configure the build you run
 ! > cmake ..
 ! Which creates the build files (Makefiles etc.) needed to build and test your program.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -35,11 +35,11 @@ contains
 end module pangram
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `pangram_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -42,11 +42,11 @@ contains
 end module raindrops
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `raindrops_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -45,11 +45,11 @@ contains
 end module rna_transcription
 ```
 
-Now create a build directory (eg. `mkdir Debug`), change into it and run `cmake ..`  to configure the build.
+Now create a build directory (eg. `mkdir build`), change into it and run `cmake ..`  to configure the build.
 
 Note, that the first time you call `cmake ..` it will download the `testlib` automatically which is used in `rna_transcription_test.f90`.
 
-The `testib` can also be downloaded manually from github see 
+The `testib` can also be downloaded manually from github. For more information see [Running the tests](https://exercism.io/tracks/fortran/tests).
 
 Now build (eg. `make`)  and run tests with `ctest -V`. For a detailed description see [Running the Tests](https://exercism.io/tracks/fortran/tests).
 


### PR DESCRIPTION
According to discussion on slack and discussion of #60, we now use
"build" as the name for the build directory instead of "Debug" which is
misleading.

Note: For larger real projects, a developer will usually have multiple
build directories according to CMAKE_BUILD_TYPE, see https://cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TYPE.html
but for the learners of Fortran this is not yet relevant.