### PR TITLE
Update resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,9 @@ We simulate Test-Driven Development (TDD) by implementing the tests in order of 
 - helps triangulate a solution to be more generic, or
 - requires new functionality incrementally.
 
-Test files should use the following format:
+### Fortran Track ###
 
-```
-# include the body of an example test
-```
+Test files for the Fortran track should be created with the Python3 script `bin/create_fortran_test.py` which is documented [here](docs/MAINTAINERS.md).
 
 ## Submitting a Pull Request ##
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,0 +1,42 @@
+## For maintainers
+
+### Helper script for creating fortran tests: create\_fortran\_test.py
+
+A easy way to create an exercise test is to use the script
+bin/create\_fortran\_test.py
+
+Use this script to create an initial <exercise>\_test.f90 file which can be used as a skeleton for your test.
+Typically, you will have to replace the 'response'-function in the generated file with the correct function call.
+
+Also note that Fortran has issues with special characters such as `\n` and `\t` so take special care handling these.
+
+#### Prerequsites
+- Working cmake and fortran compiler
+- Python3.x (You can make it may work with Python2, but I have not made the
+effort to make it backwards compatible)
+- latest version of https://github.com/exercism/problem-specifications.git
+
+#### Work flow for creating a new test
+- pull latest changes from exercism/problem-specifications
+- run this script for the example you want to create
+- copy config/CMakeLists.txt for exercise directory
+- implement working exercise
+- fix potential problematic tests (see eg. exercise/bob "Test 20" and "Test 24")
+- ensure ctest validates without errors
+- open a pull request with your changes
+
+For bob example:
+
+```bash
+$ python3 config/create_fortran_test.py -j ../../../exercism/problem-specifications/exercises/bob/canonical-data.json -t exercises/bob/bob_test.f90
+Namespace(json='../../../exercism/problem-specifications/exercises/bob/canonical-data.json', target='exercises/bob/bob_test.f90')
+Wrote : exercises/bob/bob_test.f90
+$ cp config/CMakeLists.txt exercises/bob/.
+$ cd exercises/bob
+$ touch bob.f90
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+$ ctest -V
+```

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,17 +1,17 @@
 ## For maintainers
 
-### Helper script for creating fortran tests: create\_fortran\_test.py
+### Helper script for creating Fortran tests: create\_fortran\_test.py
 
 An easy way to create an exercise test is to use the script
 `bin/create\_fortran\_test.py`
 
-Use this script to create an initial <exercise>\_test.f90 file which can be used as a skeleton for your test.
+Use this script to create an initial <exercise>\_test.f90 file which can be used as a template for your test.
 Typically, you will have to replace the 'response'-function in the generated file with the correct function call.
 
 Also note that Fortran has issues with special characters such as `\n` and `\t` so take special care handling these.
 
 #### Prerequsites
-- Working cmake and fortran compiler
+- Working CMake and Fortran compiler
 - Python3.x (You can make it may work with Python2, but I have not made the
 effort to make it backwards compatible)
 - latest version of https://github.com/exercism/problem-specifications.git

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -3,7 +3,7 @@
 ### Helper script for creating fortran tests: create\_fortran\_test.py
 
 An easy way to create an exercise test is to use the script
-bin/create\_fortran\_test.py
+`bin/create\_fortran\_test.py`
 
 Use this script to create an initial <exercise>\_test.f90 file which can be used as a skeleton for your test.
 Typically, you will have to replace the 'response'-function in the generated file with the correct function call.

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -19,7 +19,7 @@ effort to make it backwards compatible)
 #### Work flow for creating a new test
 - pull latest changes from exercism/problem-specifications
 - run this script for the example you want to create
-- copy config/CMakeLists.txt for exercise directory
+- copy `config/CMakeLists.txt` for exercise directory
 - implement working exercise
 - fix potential problematic tests (see eg. exercise/bob "Test 20" and "Test 24")
 - ensure ctest validates without errors

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -22,7 +22,7 @@ effort to make it backwards compatible)
 - copy `config/CMakeLists.txt` for exercise directory
 - implement working exercise
 - fix potential problematic tests (see eg. exercise/bob "Test 20" and "Test 24")
-- ensure ctest validates without errors
+- ensure `ctest` command validates without errors
 - open a pull request with your changes
 
 For bob example:

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 ### Helper script for creating fortran tests: create\_fortran\_test.py
 
-A easy way to create an exercise test is to use the script
+An easy way to create an exercise test is to use the script
 bin/create\_fortran\_test.py
 
 Use this script to create an initial <exercise>\_test.f90 file which can be used as a skeleton for your test.

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -17,7 +17,7 @@ effort to make it backwards compatible)
 - latest version of https://github.com/exercism/problem-specifications.git
 
 #### Work flow for creating a new test
-- pull latest changes from exercism/problem-specifications
+- pull latest changes from `exercism/problem-specifications`
 - run this script for the example you want to create
 - copy `config/CMakeLists.txt` for exercise directory
 - implement working exercise

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,42 +1,10 @@
-## For maintainers
+# Fortran resources
 
-### Helper script for creating fortran tests: create\_fortran\_test.py
+## Links
 
-A easy way to create an exercise test is to use the script
-bin/create\_fortran\_test.py
+- [Gnu Fortran (GFortran)](https://gcc.gnu.org/fortran/)
+- [GNU Fortran Documentation](https://gcc.gnu.org/onlinedocs/gfortran/)
+- [CMake Documentation](https://cmake.org/cmake/help/latest/)
+- [Intel Fortran](https://software.intel.com/en-us/fortran-compilers)
+- [Visual Studio](https://visualstudio.microsoft.com/)
 
-Use this script to create an initial <exercise>\_test.f90 file which can be used as a skeleton for your test.
-Typically, you will have to replace the 'response'-function in the generated file with the correct function call.
-
-Also note that Fortran has issues with special characters such as `\n` and `\t` so take special care handling these.
-
-#### Prerequsites
-- Working cmake and fortran compiler
-- Python3.x (You can make it may work with Python2, but I have not made the
-effort to make it backwards compatible)
-- latest version of https://github.com/exercism/problem-specifications.git
-
-#### Work flow for creating a new test
-- pull latest changes from exercism/problem-specifications
-- run this script for the example you want to create
-- copy config/CMakeLists.txt for exercise directory
-- implement working exercise
-- fix potential problematic tests (see eg. exercise/bob "Test 20" and "Test 24")
-- ensure ctest validates without errors
-- open a pull request with your changes
-
-For bob example:
-
-```bash
-$ python3 config/create_fortran_test.py -j ../../../exercism/problem-specifications/exercises/bob/canonical-data.json -t exercises/bob/bob_test.f90
-Namespace(json='../../../exercism/problem-specifications/exercises/bob/canonical-data.json', target='exercises/bob/bob_test.f90')
-Wrote : exercises/bob/bob_test.f90
-$ cp config/CMakeLists.txt exercises/bob/.
-$ cd exercises/bob
-$ touch bob.f90
-$ mkdir build
-$ cd build
-$ cmake ..
-$ make
-$ ctest -V
-```


### PR DESCRIPTION
I had misunderstood `docs/RESOURCES.md` and have now filled it with resource
links for students.

The wrong information for maintainers now moved to `docs/MAINTAINERS.md`
and linked it from `README.md`.