### PR TITLE
Add tooling & CI for CMakeLists.txt

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,11 @@
+name: Check cmake
+
+on: [push, pull_request]
+
+jobs:
+  compare-to-master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: "Compare cmake files to master copy"
+        run: ./bin/compare-cmake-files-to-master

--- a/bin/compare-cmake-files-to-master
+++ b/bin/compare-cmake-files-to-master
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+changed_files=$(diff -q --from-file=config/CMakeLists.txt exercises/*/CMakeLists.txt)
+
+if [ -n "$changed_files" ]; then
+    echo "$changed_files"
+    echo "run bin/update-cmake-files to overwrite all exercise cmake files with the master copy"
+    exit 1
+fi

--- a/bin/update-cmake-files
+++ b/bin/update-cmake-files
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for dir in exercises/*/; do
+    cp config/CMakeLists.txt "$dir"/CMakeLists.txt
+done
+
+exit 0

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -19,7 +19,7 @@ effort to make it backwards compatible)
 #### Work flow for creating a new test
 - pull latest changes from `exercism/problem-specifications`
 - run this script for the example you want to create
-- copy `config/CMakeLists.txt` for exercise directory
+- copy `config/CMakeLists.txt` to exercise directory (You can use `bin/update-cmake-files` for this)
 - implement working exercise
 - fix potential problematic tests (see eg. exercise/bob "Test 20" and "Test 24")
 - ensure `ctest` command validates without errors
@@ -40,3 +40,6 @@ $ cmake ..
 $ make
 $ ctest -V
 ```
+
+#### Changing `CMakeLists.txt`
+When changing the cmake file, update the master copy in `config/` and use `bin/update-cmake-files` to copy it to all exercise directories.


### PR DESCRIPTION
- On pushes/PRs, CI will test that `config/CMakeLists.txt` and the `CMakeLists.txt` files in the exercise directories don't diverge. **This effectively makes `config/CMakeLists.txt` the master copy**
- `bin/update-cmake-files` copies `config/CMakeLists.txt` to all exercise directory, **overwriting** the file that's been there

For now, I decided to not automatically update the files in the exercise directories, so one will have to run `bin/update-cmake-files` manually. It would add a lot of complexity that is probably not worth it.