### PR TITLE
Create all exercises script

### DIFF
--- a/bin/create_all.py
+++ b/bin/create_all.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+import os
+import glob
+import create_fortran_test
+
+
+
+jsons=glob.glob( '../../exercism/problem-specifications/exercises/*/*.json')
+
+for j in jsons:
+    exname=os.path.basename(os.path.dirname(j))
+    exname_us=exname.replace('-','_')
+    expath=os.path.join('new_exercises',exname)
+    ex_test_path=os.path.join(expath, exname_us+'_test.f90')
+    if os.path.isdir(expath):
+        print(f'Found {expath}, not creating this exercise')
+    else:
+        print(f'Not found {expath}, creating this exercise from {j}')
+        os.mkdir(expath)
+        try:
+            create_fortran_test.create_test(ex_test_path, j)
+        except:
+            print(f'An exception happened for exercise {expath} from {j}')
+            print('Continuing....')
+        print(f'Created {expath}')
+
+print('Done')


### PR DESCRIPTION
Added a script for creating all exercises not in "exercise"-directory
and writes the new ones in "new_exercises" directory.

It fails for the exercises that throw an error which in not available in fortran.

Minor fix to the test creation script and adding a stub-file by default.