### PR TITLE
🤖 Update tests.toml files to latest spec

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# basic
-"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
 
-# lowercase words
-"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
 
-# punctuation
-"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
 
-# all caps word
-"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
 
-# punctuation without whitespace
-"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
 
-# very long abbreviation
-"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
 
-# consecutive delimiters
-"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
 
-# apostrophes
-"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
 
-# underscore emphasis
-"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,76 +1,78 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# stating something
-"e162fead-606f-437a-a166-d051915cea8e" = true
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
 
-# shouting
-"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
 
-# shouting gibberish
-"d6c98afd-df35-4806-b55e-2c457c3ab748" = true
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
 
-# asking a question
-"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = true
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
 
-# asking a numeric question
-"81080c62-4e4d-4066-b30a-48d8d76920d9" = true
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
 
-# asking gibberish
-"2a02716d-685b-4e2e-a804-2adaf281c01e" = true
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
 
-# talking forcefully
-"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
 
-# using acronyms in regular speech
-"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
 
-# forceful question
-"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
 
-# shouting numbers
-"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
 
-# no letters
-"f7bc4b92-bdff-421e-a238-ae97f230ccac" = true
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
 
-# question with no letters
-"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = true
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
 
-# shouting with special characters
-"496143c8-1c31-4c01-8a08-88427af85c66" = true
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
 
-# shouting with no exclamation mark
-"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
 
-# statement containing question mark
-"aa8097cc-c548-4951-8856-14a404dd236a" = true
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
 
-# non-letters with question
-"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = true
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
 
-# prattling on
-"8608c508-f7de-4b17-985b-811878b3cf45" = true
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
 
-# silence
-"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
 
-# prolonged silence
-"d6c47565-372b-4b09-b1dd-c40552b8378b" = true
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
 
-# alternate silence
-"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
 
-# multiple line question
-"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
 
-# starting with whitespace
-"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
 
-# ending with whitespace
-"05b304d6-f83b-46e7-81e0-4cd3ca647900" = true
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
 
-# other whitespace
-"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = true
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
 
-# non-question ending with whitespace
-"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = true
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# square of sum 1
-"e46c542b-31fc-4506-bcae-6b62b3268537" = true
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "square of sum 1"
 
-# square of sum 5
-"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = true
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "square of sum 5"
 
-# square of sum 100
-"54ba043f-3c35-4d43-86ff-3a41625d5e86" = true
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "square of sum 100"
 
-# sum of squares 1
-"01d84507-b03e-4238-9395-dd61d03074b5" = true
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "sum of squares 1"
 
-# sum of squares 5
-"c93900cd-8cc2-4ca4-917b-dd3027023499" = true
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "sum of squares 5"
 
-# sum of squares 100
-"94807386-73e4-4d9e-8dec-69eb135b19e4" = true
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "sum of squares 100"
 
-# difference of squares 1
-"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "difference of squares 1"
 
-# difference of squares 5
-"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = true
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "difference of squares 5"
 
-# difference of squares 100
-"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = true
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "difference of squares 100"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,28 +1,30 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty strands
-"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
 
-# single letter identical strands
-"54681314-eee2-439a-9db0-b0636c656156" = true
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
 
-# single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = true
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
 
-# long identical strands
-"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
 
-# long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
 
-# disallow first strand longer
-"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
 
-# disallow second strand longer
-"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
 
-# disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
 
-# disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,4 +1,6 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/matrix/.meta/tests.toml
+++ b/exercises/practice/matrix/.meta/tests.toml
@@ -1,25 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# extract row from one number matrix
-"ca733dab-9d85-4065-9ef6-a880a951dafd" = true
+[ca733dab-9d85-4065-9ef6-a880a951dafd]
+description = "extract row from one number matrix"
 
-# can extract row
-"5c93ec93-80e1-4268-9fc2-63bc7d23385c" = true
+[5c93ec93-80e1-4268-9fc2-63bc7d23385c]
+description = "can extract row"
 
-# extract row where numbers have different widths
-"2f1aad89-ad0f-4bd2-9919-99a8bff0305a" = true
+[2f1aad89-ad0f-4bd2-9919-99a8bff0305a]
+description = "extract row where numbers have different widths"
 
-# can extract row from non-square matrix with no corresponding column
-"68f7f6ba-57e2-4e87-82d0-ad09889b5204" = true
+[68f7f6ba-57e2-4e87-82d0-ad09889b5204]
+description = "can extract row from non-square matrix with no corresponding column"
 
-# extract column from one number matrix
-"e8c74391-c93b-4aed-8bfe-f3c9beb89ebb" = true
+[e8c74391-c93b-4aed-8bfe-f3c9beb89ebb]
+description = "extract column from one number matrix"
 
-# can extract column
-"7136bdbd-b3dc-48c4-a10c-8230976d3727" = true
+[7136bdbd-b3dc-48c4-a10c-8230976d3727]
+description = "can extract column"
 
-# can extract column from non-square matrix with no corresponding row
-"ad64f8d7-bba6-4182-8adf-0c14de3d0eca" = true
+[ad64f8d7-bba6-4182-8adf-0c14de3d0eca]
+description = "can extract column from non-square matrix with no corresponding row"
 
-# extract column where numbers have different widths
-"9eddfa5c-8474-440e-ae0a-f018c2a0dd89" = true
+[9eddfa5c-8474-440e-ae0a-f018c2a0dd89]
+description = "extract column where numbers have different widths"

--- a/exercises/practice/nth-prime/.meta/tests.toml
+++ b/exercises/practice/nth-prime/.meta/tests.toml
@@ -1,16 +1,18 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# first prime
-"75c65189-8aef-471a-81de-0a90c728160c" = true
+[75c65189-8aef-471a-81de-0a90c728160c]
+description = "first prime"
 
-# second prime
-"2c38804c-295f-4701-b728-56dea34fd1a0" = true
+[2c38804c-295f-4701-b728-56dea34fd1a0]
+description = "second prime"
 
-# sixth prime
-"56692534-781e-4e8c-b1f9-3e82c1640259" = true
+[56692534-781e-4e8c-b1f9-3e82c1640259]
+description = "sixth prime"
 
-# big prime
-"fce1e979-0edb-412d-93aa-2c744e8f50ff" = true
+[fce1e979-0edb-412d-93aa-2c744e8f50ff]
+description = "big prime"
 
-# there is no zeroth prime
-"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = true
+[bd0a9eae-6df7-485b-a144-80e13c7d55b2]
+description = "there is no zeroth prime"

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,31 +1,33 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty sentence
-"64f61791-508e-4f5c-83ab-05de042b0149" = true
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
 
-# perfect lower case
-"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
 
-# only lower case
-"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
 
-# missing the letter 'x'
-"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
 
-# missing the letter 'h'
-"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
 
-# with underscores
-"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
 
-# with numbers
-"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
 
-# missing letters replaced by numbers
-"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
 
-# mixed case and punctuation
-"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
 
-# case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,55 +1,57 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
 
-# the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
 
-# the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
 
-# the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
 
-# the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
 
-# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
 
-# the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
 
-# the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
 
-# the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
 
-# the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
 
-# the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
 
-# the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
 
-# the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
 
-# the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
 
-# the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
 
-# the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
 
-# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
 
-# the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,19 +1,21 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Empty RNA sequence
-"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
 
-# RNA complement of cytosine is guanine
-"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
 
-# RNA complement of guanine is cytosine
-"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
 
-# RNA complement of thymine is adenine
-"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
 
-# RNA complement of adenine is uracil
-"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
 
-# RNA complement
-"79ed2757-f018-4f47-a1d7-34a559392dbf" = true
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"


### PR DESCRIPTION
Track maintainers found that they wanted to add comments to the tests.toml file to e.g. indicate _why_ a test was not included.
Unfortunately, running configlet sync would re-generate the entire file so any manually added comments were lost.

In this PR we're updating the format of tests.toml files to support adding comments.
We do this by creating a separate table for each test case which has `description` and `include` fields.
Tracks are then free to add additional fields, like a `comment` field, but also any other fields they feel might be useful to them.

configlet has _not_ yet been updated to support this new format, but we hope to do this soon. Sorry for the inconvenience.

For more information, see this discussion: https://github.com/exercism/configlet/issues/186

## Implementation

The PR expects the tests.toml files to be in their original format:

```toml
# <description>
"<uuid>" = <include>
```

This is transformed to:

```toml
[<uuid>]
description = "<description>"
include = <include>
```

## Example

```toml
# one factor has multiples within limit
"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
```

becomes

```toml
[361e4e50-c89b-4f60-95ef-5bc5c595490a]
description = "one factor has multiples within limit"
include = true
```

## Existing comments

As some tracks have manually added comments to tests, we try to detect them by assuming they are either:

- Added as a line comment _before_ the description (we'll ignore empty lines)
- Added as an inline comment _after_ boolean include value

For any such manually detected comments, we'll add a `comment` field.

## Tracking

https://github.com/exercism/v3-launch/issues/22
