### PR TITLE
Write doc meta files

### DIFF
--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -192,8 +192,8 @@ def add_meta_and_doc_file(test_file_name, json_name):
     return None
 
 def write_instructions(desc_file, instruction_file):
-    lines = open(desc_file).readlines()
-    with open(instruction_file, 'w') as of:
+    lines = open(desc_file, encoding='utf-8').readlines()
+    with open(instruction_file, 'w', encoding='utf-8') as of:
         for li in lines:
             of.write(li.replace('# Description','# Instructions'))
     print('wrote %s'%instruction_file)

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -169,13 +169,14 @@ def add_meta_and_doc_file(test_file_name, json_name):
     """
     create 
     
-        .meta/tests.toml 
         .meta/config.json
         .docs/instructions.md  (based on ../problem-specifications/exercises/[EXERCISE]/description.md)
 
     for test_file_name
 
-    Not yet implemented.
+    The file .meta/tests.toml will be created with:
+        configlet sync
+
     """
     test_dir_name = os.path.dirname(test_file_name)
     exercise_name = os.path.basename(test_dir_name).replace('-', '_')

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -94,12 +94,12 @@ def create_single_test(j):
     si = []
     global TEST_NUMBER
     # there is a better way to do this by I dont have a good idea...
-    print('A', TEST_NUMBER)
+    #print('A', TEST_NUMBER)
     for c in j['cases']:
         if 'cases' in c:
             si.extend(create_single_test(c))
         else:
-            print('B', TEST_NUMBER)
+            #print('B', TEST_NUMBER)
             TEST_NUMBER = TEST_NUMBER +1
             si.extend(write_testcase(c,TEST_NUMBER))
     return si

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -91,10 +91,7 @@ def write_testcase(c, TEST_NUMBER):
     si.append('  call assert_equal({}, {}, "{}")'.format(expected, inp, description))
     return si
 
-
-def create_single_test(j):
-    """Walk through the json cases and recursively write the test cases"""
-    
+def flatten_test_cases(j):
     # unpack nested cases
     nested_cases = j['cases']
     flattened_cases = []
@@ -107,6 +104,14 @@ def create_single_test(j):
                 flattened_cases.extend(cases)
             else:
                 flattened_cases.append(cases)
+
+    return flattened_cases
+
+
+def create_single_test(j):
+    """Walk through the json cases and recursively write the test cases"""
+    
+    flattened_cases  = flatten_test_cases(j)
     
     si = []
     for i,c in enumerate(flattened_cases):

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -68,7 +68,10 @@ def write_testcase(c, TEST_NUMBER):
     fcall = c['property']
     error = c['expected']['error'] if type(c['expected']) is dict and 'error' in c['expected'] else None
     fargs = [v for v in c['input'].values()]
-    inp = '{}({}'.format(fcall, fix_and_quote_fortran_multiline(fargs[0]))
+    if fargs:
+        inp = '{}({}'.format(fcall, fix_and_quote_fortran_multiline(fargs[0]))
+    else:
+        inp = '{}({}'.format(fcall, fix_and_quote_fortran_multiline(" ")) # empty array
     for a in fargs[1:]:
         inp = '{}, {}'.format(inp, fix_and_quote_fortran_multiline(a))
     inp = '{})'.format(inp)

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -263,12 +263,23 @@ def write_tests_toml(json_name, test_toml):
 
 """
         of.write(comment)
-        for tnum, c in enumerate(j['cases']):
-            if 'cases' in c:
-                assert(False)
-            of.write('[%s]\n'%c['uuid'])
-            of.write('description = "%s"\n\n'%c['description'])
+        uuids_descs = get_uuid_and_description(j['cases'])
+        for uuid, desc in uuids_descs:
+            of.write('[%s]\n'%uuid)
+            of.write('description = "%s"\n\n'%desc)
     print('wrote %s'%test_toml)
+
+def get_uuid_and_description(cases):
+    uuids_descs = []
+    #print(cases)
+    for c in cases:
+        if 'cases' in c:
+            uuids_descs2 = get_uuid_and_description(c['cases'])
+            uuids_descs.extend(uuids_descs2)
+        #print(c)
+        if 'uuid' in c:
+            uuids_descs.append( (c['uuid'], c['description']) )
+    return uuids_descs
 
 
 if __name__ == '__main__':

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -92,7 +92,7 @@ def write_testcase(c, TEST_NUMBER):
     return si
 
 TEST_NUMBER=0
-def create_single_test(j):
+def create_single_test1(j):
     """Walk through the json cases and recursively write the test cases"""
     si = []
     global TEST_NUMBER
@@ -107,6 +107,24 @@ def create_single_test(j):
             si.extend(write_testcase(c,TEST_NUMBER))
     return si
 
+def create_single_test(j):
+    """Walk through the json cases and recursively write the test cases"""
+    
+    # unpack nested cases
+    nested_cases = j['cases']
+    flattened_cases = []
+
+    while len(nested_cases) > 0:
+        cases = nested_cases.pop()
+        if 'cases' in cases:
+            map(nested_cases.append, cases['cases'])
+        else:
+            map(flattened_cases.append, cases)
+    
+    si = []
+    for i,c in enumerate(flattened_cases):
+        si.extend(create_single_test(c,i))
+    return si
 
 def create_stub(exercise, stub_file_name):
     stub_lines = """

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -91,21 +91,6 @@ def write_testcase(c, TEST_NUMBER):
     si.append('  call assert_equal({}, {}, "{}")'.format(expected, inp, description))
     return si
 
-TEST_NUMBER=0
-def create_single_test1(j):
-    """Walk through the json cases and recursively write the test cases"""
-    si = []
-    global TEST_NUMBER
-    # there is a better way to do this by I dont have a good idea...
-    #print('A', TEST_NUMBER)
-    for c in j['cases']:
-        if 'cases' in c:
-            si.extend(create_single_test(c))
-        else:
-            #print('B', TEST_NUMBER)
-            TEST_NUMBER = TEST_NUMBER +1
-            si.extend(write_testcase(c,TEST_NUMBER))
-    return si
 
 def create_single_test(j):
     """Walk through the json cases and recursively write the test cases"""
@@ -113,17 +98,19 @@ def create_single_test(j):
     # unpack nested cases
     nested_cases = j['cases']
     flattened_cases = []
-
     while len(nested_cases) > 0:
         cases = nested_cases.pop()
         if 'cases' in cases:
-            map(nested_cases.append, cases['cases'])
+            nested_cases.append(cases['cases'])
         else:
-            map(flattened_cases.append, cases)
+            if isinstance(cases, list):
+                flattened_cases.extend(cases)
+            else:
+                flattened_cases.append(cases)
     
     si = []
     for i,c in enumerate(flattened_cases):
-        si.extend(create_single_test(c,i))
+        si.extend(write_testcase(c,i))
     return si
 
 def create_stub(exercise, stub_file_name):

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -175,7 +175,7 @@ def add_meta_and_doc_file(test_file_name, json_name):
     Not yet implemented.
     """
     test_dir_name = os.path.dirname(test_file_name)
-    test_name = os.path.basename(test_dir_name)
+    exercise_name = os.path.basename(test_dir_name).replace('-', '_')
     meta_dir = os.path.join( test_dir_name, '.meta')
     test_toml = os.path.join( meta_dir, 'tests.toml')
     write_tests_toml(json_name, test_toml)
@@ -187,7 +187,7 @@ def add_meta_and_doc_file(test_file_name, json_name):
     
     meta_yaml = os.path.join( os.path.dirname(json_name),  'metadata.yml')
     local_config_json = os.path.join(meta_dir, 'config.json')
-    write_config_json(test_name, meta_yaml, local_config_json)
+    write_config_json(exercise_name, meta_yaml, local_config_json)
 
     return None
 
@@ -199,7 +199,7 @@ def write_instructions(desc_file, instruction_file):
     print('wrote %s'%instruction_file)
 
 
-def write_config_json(test_name, meta_yaml, local_config_json, authors=['pclausen'] ):
+def write_config_json(exercise_name, meta_yaml, local_config_json, authors=['pclausen'] ):
     """
     {
   "blurb": "Convert a long phrase to its acronym",
@@ -228,10 +228,10 @@ def write_config_json(test_name, meta_yaml, local_config_json, authors=['pclause
         "authors": authors,
         "files": {
             "solution": [
-                "%s.f90"%test_name
+                "%s.f90"%exercise_name
             ],
             "test": [
-                "%s_test.f90"%test_name
+                "%s_test.f90"%exercise_name
             ],
             "example": [
                 ".meta/example.f90"

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -158,7 +158,7 @@ program %s_test_main
     create_stub(exercise, stub_file_name)
 
 
-def add_meta_and_doc_file(test_name, json_name):
+def add_meta_and_doc_file(test_file_name, json_name):
     """
     create 
     
@@ -166,11 +166,12 @@ def add_meta_and_doc_file(test_name, json_name):
         .meta/config.json
         .docs/instructions.md  (based on ../problem-specifications/exercises/[EXERCISE]/description.md)
 
-    for test_name
+    for test_file_name
 
     Not yet implemented.
     """
-    test_dir_name = os.path.dirname(test_name)
+    test_dir_name = os.path.dirname(test_file_name)
+    test_name = os.path.basename(test_dir_name)
     meta_dir = os.path.join( test_dir_name, '.meta')
     test_toml = os.path.join( meta_dir, 'tests.toml')
     write_tests_toml(json_name, test_toml)
@@ -226,10 +227,10 @@ def write_config_json(test_name, meta_yaml, local_config_json, authors=['pclause
                 "%s.f90"%test_name
             ],
             "test": [
-              "%s_test.f90"%test_name
+                "%s_test.f90"%test_name
             ],
             "example": [
-              ".meta/example.f90"
+                ".meta/example.f90"
             ]
         }
     } )

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -177,9 +177,7 @@ def add_meta_and_doc_file(test_file_name, json_name):
     test_dir_name = os.path.dirname(test_file_name)
     exercise_name = os.path.basename(test_dir_name).replace('-', '_')
     meta_dir = os.path.join( test_dir_name, '.meta')
-    test_toml = os.path.join( meta_dir, 'tests.toml')
-    write_tests_toml(json_name, test_toml)
-
+    
     doc_dir = os.path.join( test_dir_name, '.docs')
     desc_file = os.path.join( os.path.dirname(json_name),  'description.md')
     instruction_file =  os.path.join(doc_dir, 'instructions.md')
@@ -247,44 +245,14 @@ def write_config_json(exercise_name, meta_yaml, local_config_json, authors=['pcl
 def get_meta_info(meta_yaml):
     lines = open(meta_yaml).readlines()
     lines[0] ="{"
+    lines[-1] = lines[-1].strip() # avoid comma to replaced with \n in last line
     lines.append("}")
-    lines[3] = lines[3].strip() # avoid comma in last line
     lines2 = [re.sub(r'^(\w+):',r'"\1":', li)
         for li in lines ]
-    lines3 = [li.replace('\n',',') for li in lines2 ]    
+    lines3 = [li.replace('\n',',') for li in lines2 ]
     meta_info = json.loads(''.join(lines3))
     return meta_info    
 
-
-
-def write_tests_toml(json_name, test_toml):
-    j = None
-    with open(json_name) as f:
-        j = json.load(f)
-    with open(test_toml,'w') as of:
-        comment="""# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
-"""
-        of.write(comment)
-        uuids_descs = get_uuid_and_description(j['cases'])
-        for uuid, desc in uuids_descs:
-            of.write('[%s]\n'%uuid)
-            of.write('description = "%s"\n\n'%desc)
-    print('wrote %s'%test_toml)
-
-def get_uuid_and_description(cases):
-    uuids_descs = []
-    #print(cases)
-    for c in cases:
-        if 'cases' in c:
-            uuids_descs2 = get_uuid_and_description(c['cases'])
-            uuids_descs.extend(uuids_descs2)
-        #print(c)
-        if 'uuid' in c:
-            uuids_descs.append( (c['uuid'], c['description']) )
-    return uuids_descs
 
 
 if __name__ == '__main__':

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -44,7 +44,6 @@ import argparse
 import os
 import re 
 
-
 def fix_and_quote_fortran_multiline(txt):
     """Fortran can't handle multiple, so adding continuation character '&'
     if necessary"""
@@ -53,10 +52,10 @@ def fix_and_quote_fortran_multiline(txt):
         return '"%s"'%txt
     return txt
 
-def write_testcase(c, tnum):
+def write_testcase(c, TEST_NUMBER):
     """Putting the test case together.
     Format:
-    ! Test <tnum>: (description of test)
+    ! Test <TEST_NUMBER>: (description of test)
     call assert.... (actual test case)
     """
     si = []
@@ -82,22 +81,27 @@ def write_testcase(c, tnum):
         expected = '.false.'
     else:
         expected = fix_and_quote_fortran_multiline(expected)
-    si.append('  ! Test %d: %s'%(tnum+1, description))
+    si.append('  ! Test %d: %s'%(TEST_NUMBER, description))
     if error:
         expected = 'ERROR'
         si.append('  ! ERROR: %s'%(error))
     si.append('  call assert_equal({}, {}, "{}")'.format(expected, inp, description))
     return si
 
-
+TEST_NUMBER=0
 def create_single_test(j):
     """Walk through the json cases and recursively write the test cases"""
     si = []
-    for tnum, c in enumerate(j['cases']):
+    global TEST_NUMBER
+    # there is a better way to do this by I dont have a good idea...
+    print('A', TEST_NUMBER)
+    for c in j['cases']:
         if 'cases' in c:
             si.extend(create_single_test(c))
         else:
-            si.extend(write_testcase(c, tnum))
+            print('B', TEST_NUMBER)
+            TEST_NUMBER = TEST_NUMBER +1
+            si.extend(write_testcase(c,TEST_NUMBER))
     return si
 
 

--- a/bin/create_fortran_test.py
+++ b/bin/create_fortran_test.py
@@ -195,23 +195,24 @@ def add_meta_and_doc_file(test_file_name, json_name):
     doc_dir = os.path.join( test_dir_name, '.docs')
     desc_file = os.path.join( os.path.dirname(json_name),  'description.md')
     instruction_file =  os.path.join(doc_dir, 'instructions.md')
-    write_instructions(desc_file, instruction_file)
+    desc_file_lines = open(desc_file, encoding='utf-8').readlines()
+    write_instructions(desc_file_lines, instruction_file)
     
     meta_yaml = os.path.join( os.path.dirname(json_name),  'metadata.yml')
     local_config_json = os.path.join(meta_dir, 'config.json')
-    write_config_json(exercise_name, meta_yaml, local_config_json)
+    config_dict = get_meta_info(meta_yaml)
+    write_config_json(exercise_name, config_dict, local_config_json)
 
     return None
 
-def write_instructions(desc_file, instruction_file):
-    lines = open(desc_file, encoding='utf-8').readlines()
+def write_instructions(desc_file_lines, instruction_file):
     with open(instruction_file, 'w', encoding='utf-8') as of:
-        for li in lines:
+        for li in desc_file_lines:
             of.write(li.replace('# Description','# Instructions'))
     print('wrote %s'%instruction_file)
 
 
-def write_config_json(exercise_name, meta_yaml, local_config_json, authors=['pclausen'] ):
+def write_config_json(exercise_name, config_dict, local_config_json, authors=['pclausen'] ):
     """
     {
   "blurb": "Convert a long phrase to its acronym",
@@ -233,8 +234,6 @@ def write_config_json(exercise_name, meta_yaml, local_config_json, authors=['pcl
   "source_url": "https://github.com/monkbroc"
 }
 """
-
-    config_dict = get_meta_info(meta_yaml)
 
     config_dict.update( {
         "authors": authors,


### PR DESCRIPTION
This is not my proudest moment of Python code, but it works and that was my main objective.

bin/create_fortran_test.py now creates:

exercises\practice\<exercise>\<exercise>_test.f90
exercises\practice\<exercise>\<exercise>.f90
exercises\practice\<exercise>\.meta\tests.toml
exercises\practice\<exercise>\.docs\instructions.md
exercises\practice\<exercise>\.meta\config.json

Example output
```
python bin\create_fortran_test.py -
j ..\problem-specifications\exercises\triangle\canonical-data.json -t exercises\practice\triangle\triangle_test.f90
Namespace(json='..\\problem-specifications\\exercises\\triangle\\canonical-data.json', target='exercises\\practice\\triangle\\triangle_test.f90')
Wrote : exercises\practice\triangle\triangle_test.f90
wrote stub : exercises\practice\triangle\triangle.f90
wrote exercises\practice\triangle\.meta\tests.toml
wrote exercises\practice\triangle\.docs\instructions.md
wrote exercises\practice\triangle\.meta\config.json
```
