### PR TITLE
Trying to fix #140 Improving json format and clean up

### DIFF
--- a/exercises/practice/hamming/hamming_test.f90
+++ b/exercises/practice/hamming/hamming_test.f90
@@ -11,31 +11,31 @@ program hamming_test_main
 
   ! Test 1: empty strands
   call assert_equal(.true., compute("", "", distance), "empty strands")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance, "empty strands, distance=0")
   ! Test 2: single letter identical strands
   call assert_equal(.true., compute("A", "A", distance), "single letter identical strands")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance,"single letter identical strands, distance=0")
   ! Test 3: single letter different strands
   call assert_equal(.true., compute("G", "T", distance), "single letter different strands")
-  call assert_equal(1, distance)
+  call assert_equal(1, distance, "single letter different strands, distance=1")
   ! Test 4: long identical strands
   call assert_equal(.true., compute("GGACTGAAATCTG", "GGACTGAAATCTG", distance), "long identical strands")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance, "single letter different strands, distance=0")
   ! Test 5: long different strands
   call assert_equal(.true., compute("GGACGGATTCTG", "AGGACGGATTCT", distance), "long different strands")
-  call assert_equal(9, distance)
+  call assert_equal(9, distance,"long different strands, distance=9")
   ! Test 6: disallow first strand longer
   call assert_equal(.false., compute("AATG", "AAA", distance), "disallow first strand longer")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance,"disallow first strand longer, distance=0")
   ! Test 7: disallow second strand longer
   call assert_equal(.false., compute("ATA", "AGTG", distance), "disallow second strand longer")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance,"disallow second strand longer, distance=0")
   ! Test 8: disallow left empty strand
   call assert_equal(.false., compute("", "G", distance), "disallow left empty strand")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance,"disallow left empty strand, distance=0")
   ! Test 9: disallow right empty strand
   call assert_equal(.false., compute("G", "", distance), "disallow right empty strand")
-  call assert_equal(0, distance)
+  call assert_equal(0, distance,"disallow right empty strand, distance=0")
 
   call test_report()
 

--- a/exercises/practice/leap/leap_test.f90
+++ b/exercises/practice/leap/leap_test.f90
@@ -6,23 +6,23 @@ program leap_test_main
   implicit none
 
   ! Test 1: year not divisible by 4 in common year
-  call assert_equal(.false., is_leap_year(2015))
+  call assert_equal(.false., is_leap_year(2015),"year not divisible by 4 in common year")
   ! Test 2: year divisible by 2, not divisible by 4 in common year
-  call assert_equal(.false., is_leap_year(1970))
+  call assert_equal(.false., is_leap_year(1970), "year divisible by 2, not divisible by 4 in common year")
   ! Test 3: year divisible by 4, not divisible by 100 in leap year
-  call assert_equal(.true., is_leap_year(1996))
+  call assert_equal(.true., is_leap_year(1996), "year divisible by 4, not divisible by 100 in leap year")
   ! Test 4: year divisible by 4 and 5 is still a leap year
-  call assert_equal(.true., is_leap_year(1960))
+  call assert_equal(.true., is_leap_year(1960), "year divisible by 4 and 5 is still a leap year")
   ! Test 5: year divisible by 100, not divisible by 400 in common year
-  call assert_equal(.false., is_leap_year(2100))
-  ! Test 5: year divisible by 100 but not by 3 is still not a leap year
-  call assert_equal(.false., is_leap_year(1900))
-  ! Test 6: year divisible by 400 is leap year
-  call assert_equal(.true., is_leap_year(2000))
-  ! Test 7: year divisible by 400 but not by 125 is still a leap year
-  call assert_equal(.true., is_leap_year(2400))
-  ! Test 8: year divisible by 200, not divisible by 400 in common year
-  call assert_equal(.false., is_leap_year(1800))
+  call assert_equal(.false., is_leap_year(2100), "year divisible by 100, not divisible by 400 in common year")
+  ! Test 6: year divisible by 100 but not by 3 is still not a leap year
+  call assert_equal(.false., is_leap_year(1900), "year divisible by 100 but not by 3 is still not a leap year")
+  ! Test 7: year divisible by 400 is leap year
+  call assert_equal(.true., is_leap_year(2000), "year divisible by 400 is leap year")
+  ! Test 8: year divisible by 400 but not by 125 is still a leap year
+  call assert_equal(.true., is_leap_year(2400), "year divisible by 400 but not by 125 is still a leap year")
+  ! Test 9: year divisible by 200, not divisible by 400 in common year
+  call assert_equal(.false., is_leap_year(1800), "year divisible by 200, not divisible by 400 in common year")
 
   call test_report()
 

--- a/testlib/TesterMain.f90
+++ b/testlib/TesterMain.f90
@@ -63,17 +63,61 @@ module TesterMain
 contains
 
   !------------------------------------------------------------------
-  subroutine write_json(assert_test, msg)
+  subroutine write_json_success( test_description )
     ! -------------------------------
-    logical :: assert_test
-    character(len=*), intent(in), optional :: msg
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
-    character(len=MAX_STRING_LEN) :: exercism_fortran_json
-    character(len=MAX_STRING_LEN) :: test_name
-    logical :: exist
+    character(len=MAX_STRING_LEN) :: test_info
+    
+    if (.not. exercism_fortran_json_env_is_set() ) then
+      return
+    end if
+    
+    call open_and_write_json_test_header()
 
-    call get_environment_variable("EXERCISM_FORTRAN_JSON", exercism_fortran_json)
-    if (trim(exercism_fortran_json) /= '1') then
+    test_info = 'Test '//trim(adjustl(i_to_s(TESTS_RUN)))//': '//trim(test_description)
+
+    write(TEST_JSON_FILE_UNIT,*) '    {'
+    write(TEST_JSON_FILE_UNIT,*) '      "name"     : "'//trim(test_info)//'",'
+    write(TEST_JSON_FILE_UNIT,*) '      "test_code": "'//trim(test_info)//'",'
+    write(TEST_JSON_FILE_UNIT,*) '      "status"   : "pass",'
+    write(TEST_JSON_FILE_UNIT,*) '      "message"  : null'
+    write(TEST_JSON_FILE_UNIT,*) '    }'
+  end subroutine
+
+  !------------------------------------------------------------------
+  subroutine write_json_fail( test_description, msg )
+    ! -------------------------------
+    character(len=*), intent(in) :: test_description
+    character(len=*), intent(in) :: msg
+    ! -------------------------------
+    character(len=MAX_STRING_LEN) :: test_info
+
+    if (.not. exercism_fortran_json_env_is_set() ) then
+      return
+    end if
+
+    call open_and_write_json_test_header()
+
+    test_info = 'Test '//trim(adjustl(i_to_s(TESTS_RUN)))//': '//trim(test_description)
+
+    write(TEST_JSON_FILE_UNIT,*)   '    {'
+    write(TEST_JSON_FILE_UNIT,*)   '      "name"     : "'//trim(test_info)//'",'
+    write(TEST_JSON_FILE_UNIT,*)   '      "test_code": "'//trim(test_info)//'",'
+    write(TEST_JSON_FILE_UNIT,*)   '      "status"   : "fail",'
+    write(TEST_JSON_FILE_UNIT,*)   '      "message"  : "'//trim(msg)//'"'
+    write(TEST_JSON_FILE_UNIT,*)   '    }'
+
+  end subroutine
+
+
+  !------------------------------------------------------------------
+  subroutine open_and_write_json_test_header()
+    ! -------------------------------
+    logical :: exist
+    ! -------------------------------
+
+    if (.not. exercism_fortran_json_env_is_set() ) then
       return
     end if
     inquire(file=TEST_JSON_FILE, exist=exist)
@@ -88,40 +132,45 @@ contains
     if (TESTS_RUN>1) then
       write(TEST_JSON_FILE_UNIT,*) '    ,'
     end if
-    test_name = 'Test '//trim(adjustl(i_to_s(TESTS_RUN)))//':'
-    if (present(msg)) then
-      write(TEST_JSON_FILE_UNIT,*) '    { "name"  : "'//trim(test_name)//' '//trim(msg)//'",'
-    else
-      write(TEST_JSON_FILE_UNIT,*) '    { "name"  : "'//trim(test_name)//'",'
+  end subroutine 
+
+  !------------------------------------------------------------------
+  subroutine close_and_write_json_footer()
+
+    if ( .not. exercism_fortran_json_env_is_set() ) then
+      return 
     end if
-    if (assert_test) then
-      write(TEST_JSON_FILE_UNIT,*) '      "status": "pass" }'
+
+    open(unit=TEST_JSON_FILE_UNIT, file=TEST_JSON_FILE, status="old", position="append", action="write")
+    write(TEST_JSON_FILE_UNIT,*)   '  ],'
+    write(TEST_JSON_FILE_UNIT,*)   '  "version": 2,'
+    write(TEST_JSON_FILE_UNIT,*)   '  "message": "Test summary: '// &
+      & trim(adjustl(i_to_s(TESTS_FAILED)))//' of '//trim(adjustl(i_to_s(TESTS_RUN)))//' tests failed",'
+    if (TESTS_FAILED==0) then
+      write(TEST_JSON_FILE_UNIT,*) '  "status" : "pass"'
     else
-      write(TEST_JSON_FILE_UNIT,*) '      "status": "fail" }'
+      write(TEST_JSON_FILE_UNIT,*) '  "status" : "fail"'
     end if
+    write(TEST_JSON_FILE_UNIT,*)   '}'
+    close(TEST_JSON_FILE_UNIT)
 
   end subroutine
 
+  !------------------------------------------------------------------
+  logical function exercism_fortran_json_env_is_set()
+    character(len=MAX_STRING_LEN) :: exercism_fortran_json
+    exercism_fortran_json_env_is_set = .false.
+    call get_environment_variable("EXERCISM_FORTRAN_JSON", exercism_fortran_json)
+    if (trim(exercism_fortran_json) == '1') then
+      exercism_fortran_json_env_is_set = .true.
+    end if
+  end function
 
   !------------------------------------------------------------------
   subroutine test_report()
-    logical :: exist
-    character(len=MAX_STRING_LEN) :: exercism_fortran_json
 
     call logger('Test summary: '//trim(adjustl(i_to_s(TESTS_FAILED)))//' of '//trim(adjustl(i_to_s(TESTS_RUN)))//' tests failed')
-    call get_environment_variable("EXERCISM_FORTRAN_JSON", exercism_fortran_json)
-    inquire(file=TEST_JSON_FILE, exist=exist)
-    if (trim(exercism_fortran_json) == '1' .and. exist) then
-      open(unit=TEST_JSON_FILE_UNIT, file=TEST_JSON_FILE, status="old", position="append", action="write")
-      write(TEST_JSON_FILE_UNIT,*)   '  ],'
-      write(TEST_JSON_FILE_UNIT,*)   '  "version": 2,'
-      if (TESTS_FAILED==0) then
-        write(TEST_JSON_FILE_UNIT,*) '  "status": "pass"'
-      else
-        write(TEST_JSON_FILE_UNIT,*) '  "status": "fail"'
-      end if
-      write(TEST_JSON_FILE_UNIT,*)   '}'
-    end if
+    call close_and_write_json_footer()
     if (TESTS_FAILED==0) then
       STOP 0
     else
@@ -130,73 +179,89 @@ contains
   end subroutine
 
   !------------------------------------------------------------------
-  subroutine assert_equal_bool(e_bool,i_bool,msg)
+  subroutine assert_equal_bool(e_bool,i_bool,test_description)
     ! -------------------------------
     logical, intent(in) :: e_bool, i_bool
-    character(len=*), intent(in), optional :: msg
+    character(len=*), intent(in), optional :: test_description
     ! -------------------------------
     logical :: assert_test
+    character(len=MAX_STRING_LEN) :: expected_msg
 
     TESTS_RUN=TESTS_RUN+1
     assert_test = i_bool .eqv. e_bool
     if (.not. assert_test) then
-      call test_fail_msg(msg)
-      call elogger('Expected "'//trim(b_to_s(e_bool))//'" but got "'//trim(b_to_s(i_bool))//'"')
+      call test_fail_msg(test_description)
+      expected_msg = get_expected_msg( b_to_s(e_bool), b_to_s(i_bool))
+      call elogger(expected_msg)
+      call write_json_fail( test_description, expected_msg)
+    else
+      call write_json_success( test_description)
     endif
-    call write_json(assert_test, msg)
   end subroutine
 
   !------------------------------------------------------------------
-  subroutine assert_equal_str(estr,istr,msg)
+  subroutine assert_equal_str(estr,istr,test_description)
     ! -------------------------------
     character(len=*), intent(in) :: estr,istr
-    character(len=*), intent(in), optional :: msg
+    character(len=*), intent(in), optional :: test_description
     ! -------------------------------
     logical :: assert_test
+    character(len=MAX_STRING_LEN) :: expected_msg
+
     TESTS_RUN=TESTS_RUN+1
     assert_test = istr == estr
     if (.not. assert_test) then
-      call test_fail_msg(msg)
-      call elogger('Expected "'//trim(estr)//'" but got "'//trim(istr)//'"')
+      call test_fail_msg(test_description)
+      expected_msg = get_expected_msg(estr, istr)
+      call elogger(expected_msg)
+      call write_json_fail( test_description, expected_msg)
+    else
+      call write_json_success( test_description)
     endif
-    call write_json(assert_test, msg)
   end subroutine
 
   !------------------------------------------------------------------
-  subroutine assert_equal_int(e_int,i_int,msg)
+  subroutine assert_equal_int(e_int,i_int,test_description)
     ! -------------------------------
     integer, intent(in) :: e_int,i_int
-    character(len=*), intent(in), optional :: msg
+    character(len=*), intent(in), optional :: test_description
     ! -------------------------------
     logical :: assert_test
+    character(len=MAX_STRING_LEN) :: expected_msg
 
     TESTS_RUN=TESTS_RUN+1
     assert_test = i_int == e_int
     if (.not. assert_test) then
-      call test_fail_msg(msg)
-      call elogger('Expected "'//trim(adjustl(i_to_s(e_int)))//'" but got "' &
-      & //trim(adjustl(i_to_s(i_int)))//'"' )
+      call test_fail_msg(test_description)
+      expected_msg = get_expected_msg(adjustl(i_to_s(e_int)),adjustl(i_to_s(i_int)))
+      call elogger(expected_msg)
+      call write_json_fail( test_description, expected_msg)
+    else
+      call write_json_success( test_description)
     endif
-    call write_json(assert_test, msg)
   end subroutine
 
   !------------------------------------------------------------------
-  subroutine assert_equal_int_arr(e_int_arr, i_int_arr, msg_arr)
+  subroutine assert_equal_int_arr(e_int_arr, i_int_arr, test_description)
     ! -------------------------------
     integer, dimension(:), intent(in) :: e_int_arr, i_int_arr
-    character(len=*), intent(in) :: msg_arr
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
     logical :: assert_test
+    character(len=MAX_STRING_LEN) :: expected_msg
     integer :: i
 
     TESTS_RUN=TESTS_RUN+1
     assert_test = .false.
     assert_test = size(e_int_arr) == size(i_int_arr)
+    expected_msg = ''
     if (.not. assert_test) then
-      call test_fail_msg(msg_arr)
+      call test_fail_msg(test_description)
       call elogger('Arrays are not the same size!')
-      call elogger('Expected "'//trim(adjustl(ia_to_s(e_int_arr)))//'" but got "' &
-      & //trim(adjustl(ia_to_s(i_int_arr)))//'"' )
+      expected_msg = get_expected_msg( adjustl(ia_to_s(e_int_arr)), adjustl(ia_to_s(i_int_arr)))
+      call elogger( expected_msg )
+      call write_json_fail( test_description, expected_msg)
+
     else
       do i=1,size(e_int_arr)
         assert_test = i_int_arr(i) == e_int_arr(i)
@@ -204,51 +269,71 @@ contains
       enddo
     endif
     if (.not. assert_test) then
-      call test_fail_msg(msg_arr)
-      call elogger('Expected "'//trim(adjustl(ia_to_s(e_int_arr)))//'" but got "' &
-      & //trim(adjustl(ia_to_s(i_int_arr)))//'"' )
+      call test_fail_msg(test_description)
+      expected_msg = get_expected_msg(adjustl(ia_to_s(e_int_arr)), adjustl(ia_to_s(i_int_arr)))
+      call elogger( expected_msg )
+      call write_json_fail( test_description, expected_msg)
+    else
+      call write_json_success( test_description)
     endif
-    call write_json(assert_test, msg_arr)
   end subroutine
 
   !------------------------------------------------------------------
-  subroutine assert_equal_dble(e_dble,i_dble,msg)
+  subroutine assert_equal_dble(e_dble,i_dble,test_description)
     ! -------------------------------
     double precision, intent(in) :: e_dble,i_dble
-    character(len=*), intent(in), optional :: msg
+    character(len=*), intent(in), optional :: test_description
     ! -------------------------------
     logical :: assert_test
+    character(len=MAX_STRING_LEN) :: expected_msg
+
     TESTS_RUN=TESTS_RUN+1
     assert_test = dabs(i_dble - e_dble) < TOL
     if (.not. assert_test) then
-      call test_fail_msg(msg)
-      call elogger('Expected "'//trim(adjustl(d_to_s(e_dble)))//'" but got "'&
-      & //trim(adjustl(d_to_s(i_dble)))//'"')
+      call test_fail_msg(test_description)
+      expected_msg  = get_expected_msg( adjustl(d_to_s(e_dble)), adjustl(d_to_s(i_dble)))
+      call elogger(expected_msg)
+      call write_json_fail( test_description, expected_msg)
+    else
+      call write_json_success( test_description)
     endif
-    call write_json(assert_test, msg)
+
   end subroutine
 
   !------------------------------------------------------------------
-  subroutine assert_equal_real(e_real,i_real,msg)
+  subroutine assert_equal_real(e_real,i_real,test_description)
     ! -------------------------------
     real, intent(in) :: e_real,i_real
-    character(len=*), intent(in), optional :: msg
+    character(len=*), intent(in), optional :: test_description
     ! -------------------------------
     logical :: assert_test
+    character(len=MAX_STRING_LEN) :: expected_msg
+
     TESTS_RUN=TESTS_RUN+1
     assert_test = abs(i_real - e_real) < TOL
     if (.not. assert_test) then
-      call test_fail_msg(msg)
-      call elogger('Expected "'//trim(adjustl(r_to_s(e_real)))//'" but got "'&
-      & //trim(adjustl(r_to_s(i_real)))//'"')
+      call test_fail_msg(test_description)
+      expected_msg = get_expected_msg(adjustl(r_to_s(e_real)), adjustl(r_to_s(i_real)))
+      call elogger(expected_msg)
+      call write_json_fail( test_description, expected_msg)
+    else
+      call write_json_success( test_description)
     endif
-    call write_json(assert_test, msg)
+
   end subroutine
 
 
 !------------------------------------------------------------------
 ! utilities
 !------------------------------------------------------------------
+function get_expected_msg(expected, but_got)
+  character(len=MAX_STRING_LEN) :: get_expected_msg
+  character(len=*) :: expected
+  character(len=*) :: but_got
+  get_expected_msg  = 'Expected < '//trim(expected)//' > but got < '&
+      & //trim(but_got)//' >'
+end function 
+
 ! Integer to string
   function i_to_s(i)
     integer, intent(in) :: i
@@ -280,9 +365,9 @@ contains
 ! Logical/boolean to string
   function b_to_s(b)
     logical, intent(in) :: b
-    character(len=5) :: b_to_s
+    character(len=MAX_STRING_LEN) :: b_to_s
     if (b) then
-      b_to_s='True '
+      b_to_s='True'
     else
       b_to_s='False'
     endif
@@ -294,13 +379,13 @@ contains
 ! logger routine, in case other than stdout is needed
   subroutine logger(msg)
     character(len=*) :: msg
-    write(*,*) msg
+    write(*,*) trim(msg)
   end subroutine
 
 ! Error logger
   subroutine elogger(msg)
     character(len=*) :: msg
-    call logger('ERROR: '//msg)
+    call logger('ERROR: '//trim(msg))
   end subroutine
 
 ! Fail message and incrementing the module global TESTS_FAILED

--- a/testlib/TesterMain.f90
+++ b/testlib/TesterMain.f90
@@ -182,7 +182,7 @@ contains
   subroutine assert_equal_bool(e_bool,i_bool,test_description)
     ! -------------------------------
     logical, intent(in) :: e_bool, i_bool
-    character(len=*), intent(in), optional :: test_description
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
     logical :: assert_test
     character(len=MAX_STRING_LEN) :: expected_msg
@@ -203,7 +203,7 @@ contains
   subroutine assert_equal_str(estr,istr,test_description)
     ! -------------------------------
     character(len=*), intent(in) :: estr,istr
-    character(len=*), intent(in), optional :: test_description
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
     logical :: assert_test
     character(len=MAX_STRING_LEN) :: expected_msg
@@ -224,7 +224,7 @@ contains
   subroutine assert_equal_int(e_int,i_int,test_description)
     ! -------------------------------
     integer, intent(in) :: e_int,i_int
-    character(len=*), intent(in), optional :: test_description
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
     logical :: assert_test
     character(len=MAX_STRING_LEN) :: expected_msg
@@ -282,7 +282,7 @@ contains
   subroutine assert_equal_dble(e_dble,i_dble,test_description)
     ! -------------------------------
     double precision, intent(in) :: e_dble,i_dble
-    character(len=*), intent(in), optional :: test_description
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
     logical :: assert_test
     character(len=MAX_STRING_LEN) :: expected_msg
@@ -304,7 +304,7 @@ contains
   subroutine assert_equal_real(e_real,i_real,test_description)
     ! -------------------------------
     real, intent(in) :: e_real,i_real
-    character(len=*), intent(in), optional :: test_description
+    character(len=*), intent(in) :: test_description
     ! -------------------------------
     logical :: assert_test
     character(len=MAX_STRING_LEN) :: expected_msg
@@ -390,13 +390,9 @@ end function
 
 ! Fail message and incrementing the module global TESTS_FAILED
   subroutine test_fail_msg(msg)
-    character(len=*), optional :: msg
+    character(len=*) :: msg
     TESTS_FAILED=TESTS_FAILED+1
-    if (present(msg)) then
-      call elogger('Test '//trim(adjustl(i_to_s(TESTS_RUN)))//': '//msg)
-    else
-      call elogger('Test '//trim(adjustl(i_to_s(TESTS_RUN))))
-    end if
+    call elogger('Test '//trim(adjustl(i_to_s(TESTS_RUN)))//': '//msg)
   end subroutine
 
 


### PR DESCRIPTION
Trying to fix #140 Improving json format and clean up

I changed the output from

```
1:  ERROR: Test 23: non-question ending with whitespace
1:  ERROR: Expected "Whatever." but got "Whatever. caascassa"
```

to ("message" --> < message > ):

```
1:  ERROR: Expected < Whatever. > but got < Whatever. caascassa >
1:  Test summary: 8 of 23 tests failed
```

The reason is that the quotation sign is problematic in json. But maybe it is not the best in STDOUT. 
