### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello_world.f90
+++ b/exercises/practice/hello-world/hello_world.f90
@@ -1,9 +1,8 @@
 module hello_world
-  implicit none
 contains
-
   function hello()
     character(13) :: hello
+    hello = 'Goodbye, Mars!'
 
   end function hello
 


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46