### PR TITLE
Remove "message" from json by status=pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin/configlet.exe
 __pycache__
 # make and testing artifacts
 build
+build_intel
 exercises/practice/*/*_build_all.f90
 exercises/practice/*/testlib
 .vscode

--- a/testlib/TesterMain.f90
+++ b/testlib/TesterMain.f90
@@ -81,7 +81,6 @@ contains
     write(TEST_JSON_FILE_UNIT,*) '      "name"     : "'//trim(test_info)//'",'
     write(TEST_JSON_FILE_UNIT,*) '      "test_code": "'//trim(test_info)//'",'
     write(TEST_JSON_FILE_UNIT,*) '      "status"   : "pass",'
-    write(TEST_JSON_FILE_UNIT,*) '      "message"  : null'
     write(TEST_JSON_FILE_UNIT,*) '    }'
   end subroutine
 
@@ -144,12 +143,13 @@ contains
     open(unit=TEST_JSON_FILE_UNIT, file=TEST_JSON_FILE, status="old", position="append", action="write")
     write(TEST_JSON_FILE_UNIT,*)   '  ],'
     write(TEST_JSON_FILE_UNIT,*)   '  "version": 2,'
-    write(TEST_JSON_FILE_UNIT,*)   '  "message": "Test summary: '// &
-      & trim(adjustl(i_to_s(TESTS_FAILED)))//' of '//trim(adjustl(i_to_s(TESTS_RUN)))//' tests failed",'
     if (TESTS_FAILED==0) then
       write(TEST_JSON_FILE_UNIT,*) '  "status" : "pass"'
     else
       write(TEST_JSON_FILE_UNIT,*) '  "status" : "fail"'
+      ! only write message on fail:
+      write(TEST_JSON_FILE_UNIT,*) '  "message": "Test summary: '// &
+      & trim(adjustl(i_to_s(TESTS_FAILED)))//' of '//trim(adjustl(i_to_s(TESTS_RUN)))//' tests failed",'
     end if
     write(TEST_JSON_FILE_UNIT,*)   '}'
     close(TEST_JSON_FILE_UNIT)


### PR DESCRIPTION
According to
https://github.com/exercism/docs/blob/main/building/tooling/test-runners/interface.md#message

at "status":"pass", message should be null or omitted. We omit the message.

Fix #151 