### PR TITLE
Remove unused variable from hamming stub code

### DIFF
--- a/exercises/practice/hamming/hamming.f90
+++ b/exercises/practice/hamming/hamming.f90
@@ -4,7 +4,7 @@ contains
 
   function compute(strand1, strand2, distance)
       character(*) :: strand1, strand2
-      integer :: distance, i
+      integer :: distance
       logical :: compute
 
   end function compute


### PR DESCRIPTION
There's an `i` variable provided for the Hamming Code exercise, but it's not part of the function signature.

It's likely a user might also want an integer `i`, e.g. as an index to iterate characters as part of a `do` loop, but they also might want to call it `index` or `ptr` or something else equally reasonable.

My suggestion here is to remove it and let students decide their approach.