### PR TITLE
Improve matrix stub

### DIFF
--- a/exercises/practice/matrix/matrix.f90
+++ b/exercises/practice/matrix/matrix.f90
@@ -4,25 +4,25 @@ module matrix
 
 contains
 
-  function row(m, m_dim, i) result(r)
-    integer, dimension(2), intent(in) :: m_dim
+  function row(matrix, dims, i) result(r)
+    integer, dimension(2), intent(in) :: dims
     !! Matrix dimensions (nrows, ncols)
-    character(len=*), dimension(m_dim(1)), intent(in) :: m
+    character(len=*), dimension(dims(1)), intent(in) :: matrix
     !! Matrix as a 1-d array of strings
     integer, intent(in) :: i
     !! Row index
-    integer, dimension(m_dim(2)) :: r
+    integer, dimension(dims(2)) :: r
     r(:) = 0
   end function
 
-  function column(m, m_dim, j) result(c)
-    integer, dimension(2), intent(in) :: m_dim
+  function column(matrix, dims, j) result(c)
+    integer, dimension(2), intent(in) :: dims
     !! Matrix dimensions (nrows, ncols)
-    character(len=*), dimension(m_dim(1)), intent(in) :: m
+    character(len=*), dimension(dims(1)), intent(in) :: matrix
     !! Matrix as a 1-d array of strings
     integer, intent(in) :: j
     !! Column index
-    integer, dimension(m_dim(1)) :: c
+    integer, dimension(dims(1)) :: c
     c(:) = 0
   end function
 

--- a/exercises/practice/matrix/matrix.f90
+++ b/exercises/practice/matrix/matrix.f90
@@ -5,20 +5,18 @@ module matrix
 contains
 
   function row(m, m_dim, i) result(r)
-    character(len=*) :: m
     integer, intent(in) :: m_dim(2)
+    character(len=*), dimension(m_dim(1)), intent(in) :: m
     integer, intent(in) :: i
-    integer,dimension(m_dim(2)) :: r
-    integer :: A(m_dim(1),m_dim(2))
+    integer, dimension(m_dim(2)) :: r
     r(:) = 0
   end function
 
   function column(m, m_dim, j) result(c)
-    character(len=*) :: m
     integer, intent(in) :: m_dim(2)
+    character(len=*), dimension(m_dim(1)), intent(in) :: m
     integer, intent(in) :: j
     integer, dimension(m_dim(1)) :: c
-    integer :: A(m_dim(1),m_dim(2))
     c(:) = 0
   end function
 

--- a/exercises/practice/matrix/matrix.f90
+++ b/exercises/practice/matrix/matrix.f90
@@ -5,17 +5,23 @@ module matrix
 contains
 
   function row(m, m_dim, i) result(r)
-    integer, intent(in) :: m_dim(2)
+    integer, dimension(2), intent(in) :: m_dim
+    !! Matrix dimensions (nrows, ncols)
     character(len=*), dimension(m_dim(1)), intent(in) :: m
+    !! Matrix as a 1-d array of strings
     integer, intent(in) :: i
+    !! Row index
     integer, dimension(m_dim(2)) :: r
     r(:) = 0
   end function
 
   function column(m, m_dim, j) result(c)
-    integer, intent(in) :: m_dim(2)
+    integer, dimension(2), intent(in) :: m_dim
+    !! Matrix dimensions (nrows, ncols)
     character(len=*), dimension(m_dim(1)), intent(in) :: m
+    !! Matrix as a 1-d array of strings
     integer, intent(in) :: j
+    !! Column index
     integer, dimension(m_dim(1)) :: c
     c(:) = 0
   end function


### PR DESCRIPTION
Addressing remaining points of #170 discussed [here](https://github.com/exercism/fortran/pull/174#issuecomment-962705915).

Also might suggest changing `m` to `matrix`, since `m` is often used for number of rows in the matrix context.
And `m_dim` -> `dims`? (I have since added these changes but can revert if desired.)