### PR TITLE
changed real_to_rational_pow parameters names

### DIFF
--- a/exercises/practice/rational-numbers/rational_numbers.f90
+++ b/exercises/practice/rational-numbers/rational_numbers.f90
@@ -34,9 +34,9 @@ contains
     ! Your code here
   end function
 
-  function real_to_rational_pow(ex,r1)
-    integer,dimension(2) ::  r1
-    real :: real_to_rational_pow,ex
+  function real_to_rational_pow(base,ex_r1)
+    integer,dimension(2) ::  ex_r1
+    real :: real_to_rational_pow,base
     ! Your code here
   end function
 


### PR DESCRIPTION
The parameter's names for **rational numbers**'s exercise function `real_to_rational_pow ` were confusing since the base of the exponentiation was named `ex` while the exponent was name `r1`. They were renamed to `base` and `ex_r1`, respectively.