### PR TITLE
Use FFLAGS instead of CMAKE_Fortran_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ set(EXERCISM_RUN_ALL_TESTS 1)
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CMAKE_Fortran_FLAGS "/warn:all")
+    set (FFLAGS ${FFLAGS} "/warn:all")
   else()
-    set (CMAKE_Fortran_FLAGS "-warn all")
+    set (FFLAGS ${FFLAGS} "-warn all")
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
-  set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  set (FFLAGS ${FFLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 
 set(practicedir ${CMAKE_CURRENT_SOURCE_DIR}/exercises/practice)


### PR DESCRIPTION
The current usage of 'CMAKE_Fortran_FLAGS' prevents passing any flags to Fortran compiler.

1. The value of `CMAKE_Fortran_FLAGS` is overwritten.
2. If `CMAKE_Fortran_FLAGS` is defined, `FFLAGS` is ignored by `cmake`.

On FreeBSD to use `gfortran13` I need to pass `-Wl,-rpath=/usr/local/lib/gcc13` and there was no way to do it (the value of `FC` is honoured).