### PR TITLE
Update exercise: reverse-string

### DIFF
--- a/config.json
+++ b/config.json
@@ -392,7 +392,7 @@
       },
       {
         "slug": "reverse-string",
-        "name": "reverse-string",
+        "name": "Reverse String",
         "uuid": "f93103ae-b124-4081-8100-59fd5b626a4f",
         "practices": [],
         "prerequisites": [],

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -4,13 +4,13 @@
   ],
   "files": {
     "solution": [
-      "example.f90"
+      "reverse_string.f90"
     ],
     "test": [
       "reverse_string_test.f90"
     ],
     "example": [
-      ".meta/reverse_string.f90"
+      ".meta/example.f90"
     ]
   },
   "blurb": "Reverse a string.",

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,14 +1,16 @@
 {
-  "authors": ["glennj"],
+  "authors": [
+    "glennj"
+  ],
   "files": {
     "solution": [
-      ".meta/example.f90"
+      "example.f90"
     ],
     "test": [
       "reverse_string_test.f90"
     ],
     "example": [
-      "reverse_string.f90"
+      ".meta/reverse_string.f90"
     ]
   },
   "blurb": "Reverse a string.",


### PR DESCRIPTION
The online editor opens the example solution instead of the stub file. When working locally, the stub file is not downloaded. I swapped* the `solution` and `example` paths in the exercise's `config.json` file.

The header on the [exercise page](https://exercism.org/tracks/fortran/exercises/reverse-string) is the slug `reverse-string`. I have updated the exercise `name` in the track's `config.json` file.

*Edit: I corrected this in a [second commit](https://github.com/simisc/exercism-fortran/commit/2b80efd8c1f5fff062e2628ad1e312515e0808dc), but it's not yet shown as part of this PR while the PR is closed.