### PR TITLE
Fix typo in Pangram exercise

### DIFF
--- a/exercises/practice/pangram/.meta/example.f90
+++ b/exercises/practice/pangram/.meta/example.f90
@@ -1,16 +1,16 @@
 module pangram
 implicit none
 contains
-  logical function is_pangram(sentance)
+  logical function is_pangram(sentence)
     implicit none
-    character(*) :: sentance
+    character(*) :: sentence
     logical :: seen(26)
     integer :: i,val
 
     seen = .false.
 
-    do i = 1,len(sentance)
-      val = to_index(sentance(i:i))
+    do i = 1,len(sentence)
+      val = to_index(sentence(i:i))
       if ( val .ne. 0 ) then
         seen(val:val) = .true.
       end if

--- a/exercises/practice/pangram/pangram.f90
+++ b/exercises/practice/pangram/pangram.f90
@@ -2,8 +2,8 @@ module pangram
   implicit none
 contains
 
-  logical function is_pangram(sentance)
-    character(*) :: sentance
+  logical function is_pangram(sentence)
+    character(*) :: sentence
 
    end function is_pangram
 


### PR DESCRIPTION
In the pangram exercise, sentence is misspelled as sentance. So I fixed the 2 code files with the typo.