### PR TITLE
Do not convert `average_run_time` back to float

### DIFF
--- a/bin/add-exercise
+++ b/bin/add-exercise
@@ -28,7 +28,7 @@ name=$(echo "${slug}" | sed 's/\b\w/\u&/g')
 uuid=$(bin/configlet uuid)
 jq --arg slug "${slug}" --arg uuid "${uuid}" --arg name "${name}" \
     '.exercises.practice += [{slug: $slug, name: $name, uuid: $uuid, practices: [], prerequisites: [], difficulty: 1}]' \
-    config.json | sed 's/"average_run_time": 2/"average_run_time": 2.0/' > config.json.tmp && mv config.json.tmp config.json
+    config.json > config.json.tmp && mv config.json.tmp config.json
 
 # Sync the exercise
 bin/configlet sync --update --yes --tests include --filepaths --metadata --docs --exercise "${slug}"


### PR DESCRIPTION
Prevent the `add-exercise` script from adding `.0` to `average_run_time`. Converting it back to float causes configlet lint (which now expects an integer) to fail.

See #212 for details.