### PR TITLE
Truncate long arrays in failed test report

### DIFF
--- a/exercises/practice/saddle-points/saddle_points_test.f90
+++ b/exercises/practice/saddle-points/saddle_points_test.f90
@@ -116,17 +116,15 @@ contains
     end if
   end subroutine assert_equal_pnt_arr
 
-  function pa_to_s(ps) result(ss)
-    type(point_t), intent(in) :: ps(:)
-    character(MAX_STRING_LEN) :: ss
-    character(5) :: s
-    integer :: i
+  function pa_to_s(p) result(s)
+    type(point_t), intent(in) :: p(:)
+    character(MAX_RESULT_STRING_LEN) :: s
+    integer :: status
 
-    ss = ''
-    do i = 1, size(ps)
-      write(s, '(A, I1, A, I1, A)') '(', ps(i)%row, ',', ps(i)%column, ')'
-      ss = trim(ss) // s
-    end do
+    write(s, '(*("(",i0,",",i0,")":","))', iostat=status) p
+    if (status /= 0) then
+      call truncate_array_string(s, '),')
+    end if
   end function pa_to_s
 
 end program saddle_points_test_main

--- a/testlib/TesterMain.f90
+++ b/testlib/TesterMain.f90
@@ -388,6 +388,11 @@ contains
 
     if (present(delim)) then
       delim_loc = index(s(:max_length), delim, back=.true.)
+    else
+      delim_loc = 0
+    end if
+
+    if (delim_loc /= 0) then
       new_length = delim_loc + len(delim) - 1
     else
       new_length = max_length

--- a/testlib/TesterMain.f90
+++ b/testlib/TesterMain.f90
@@ -43,6 +43,7 @@ module TesterMain
   integer :: TESTS_RUN = 0
   integer :: TESTS_FAILED = 0
   integer, parameter :: MAX_STRING_LEN = 80
+  integer, parameter :: MAX_RESULT_STRING_LEN = 27 ! to fit into expected_msg
   double precision, parameter :: TOL = 1.0D-8
 
   ! output file for fortran-test-runner
@@ -327,48 +328,73 @@ contains
     character(len=MAX_STRING_LEN) :: get_expected_msg
     character(len=*) :: expected
     character(len=*) :: but_got
-    get_expected_msg  = 'Expected < '//trim(expected)//' > but got < '&
-    & //trim(but_got)//' >'
+    get_expected_msg  = 'Expected < ' // trim(expected) // &
+      ' > but got < ' // trim(but_got) // ' >'
   end function
 
 ! Integer to string
   function i_to_s(i)
     integer, intent(in) :: i
-    character(len=MAX_STRING_LEN) :: i_to_s
+    character(len=MAX_RESULT_STRING_LEN) :: i_to_s
     write(i_to_s, *) i
   end function
 
 ! Integer array to string
-  function ia_to_s(i)
-    integer, dimension(:), intent(in) :: i
-    character(len=MAX_STRING_LEN) :: ia_to_s
-    write(ia_to_s, *) i
-  end function
+  function ia_to_s(i) result(s)
+    integer, intent(in) :: i(:)
+    character(len=MAX_RESULT_STRING_LEN) :: s
+    integer :: status
+
+    write(s, '(*(i0:","))', iostat=status) i
+    if (status /= 0) then
+      call truncate_array_string(s, ',')
+    end if
+  end function ia_to_s
 
 ! Double precision to string
   function d_to_s(d)
     double precision, intent(in) :: d
-    character(len=MAX_STRING_LEN) :: d_to_s
+    character(len=MAX_RESULT_STRING_LEN) :: d_to_s
     write(d_to_s, *) d
   end function
 
 ! Real to string
   function r_to_s(d)
     real, intent(in) :: d
-    character(len=MAX_STRING_LEN) :: r_to_s
+    character(len=MAX_RESULT_STRING_LEN) :: r_to_s
     write(r_to_s, *) d
   end function
 
 ! Logical/boolean to string
   function b_to_s(b)
     logical, intent(in) :: b
-    character(len=MAX_STRING_LEN) :: b_to_s
+    character(len=5) :: b_to_s
     if (b) then
       b_to_s='True'
     else
       b_to_s='False'
     endif
   end function
+
+  ! Truncate string representation of an array
+  subroutine truncate_array_string(s, delim)
+    character(len=MAX_RESULT_STRING_LEN), intent(inout) :: s
+    character(len=*), intent(in), optional :: delim
+    character(len=3) :: ellipsis
+    integer :: max_length, new_length, delim_loc
+
+    ellipsis = '…'
+    max_length = len(s) - len_trim(ellipsis)
+
+    if (present(delim)) then
+      delim_loc = index(s(:max_length), delim, back=.true.)
+      new_length = delim_loc + len(delim) - 1
+    else
+      new_length = max_length
+    end if
+
+    s = s(:new_length) // ellipsis
+  end subroutine
 
 !------------------------------------------------------------------
 ! Logger


### PR DESCRIPTION
When the actual or the expected result is too long, `ia_to_s` causes a `Fortran runtime error: End of record` (reported in [this forum post](http://forum.exercism.org/t/sieve-exercise-why-does-my-solution-cause-errors/6671)).

After these changes, each array element has its minimum width instead of the default 12 characters. If the resulting string is still too long, it is truncated and the truncation is indicated with `…`.


### Examples

#### High scores

```
1:  ERROR: Test 8: Personal top when there is only one
1:  ERROR: Arrays are not the same size!
1:  ERROR: Expected < 40,0,0 > but got < 40,0,0,0,0,0,0,0,0,0,0,… >
```

```
1:  ERROR: Test 8: Personal top when there is only one
1:  ERROR: Arrays are not the same size!
1:  ERROR: Expected < 40,0,0 > but got < 40,10000,10000,10000,… >
```

#### Sieve

```
1:  ERROR: Test 5: find primes up to 1000
1:  ERROR: Arrays are not the same size!
1:  ERROR: Expected < 2,3,5,7,11,13,17,19,23,… > but got < 2,3,4,5,6,7,8,9,10,11,… >
```

```
1:  ERROR: Test 5: find primes up to 1000
1:  ERROR: Expected < 2,3,5,7,11,13,17,19,23,… > but got < 2,999,5,7,11,13,17,19,… >
```

#### Saddle Points

```
1:  ERROR: Test 9: Can identify that saddle points in a single row matrix are those with the maximum value
1:  ERROR: Arrays are not the same size!
1:  ERROR: Expected < (1,2),(1,4) > but got < (4,4),(4,4),(4,4),(4,4),… >
```