### PR TITLE
Fix GFortran spelling in comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/darts/CMakeLists.txt
+++ b/exercises/practice/darts/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/high-scores/CMakeLists.txt
+++ b/exercises/practice/high-scores/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/isbn-verifier/CMakeLists.txt
+++ b/exercises/practice/isbn-verifier/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/linked-list/CMakeLists.txt
+++ b/exercises/practice/linked-list/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/matrix/CMakeLists.txt
+++ b/exercises/practice/matrix/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/perfect-numbers/CMakeLists.txt
+++ b/exercises/practice/perfect-numbers/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/rational-numbers/CMakeLists.txt
+++ b/exercises/practice/rational-numbers/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/saddle-points/CMakeLists.txt
+++ b/exercises/practice/saddle-points/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 

--- a/exercises/practice/yacht/CMakeLists.txt
+++ b/exercises/practice/yacht/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
     set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
   endif()
 endif()
-if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFrotran
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
   set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
 endif()
 


### PR DESCRIPTION
Comments were saying "GFrotran". Fixed.