### PR TITLE
Use cmake's add_compile_options

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/darts/CMakeLists.txt
+++ b/exercises/practice/darts/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/high-scores/CMakeLists.txt
+++ b/exercises/practice/high-scores/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/isbn-verifier/CMakeLists.txt
+++ b/exercises/practice/isbn-verifier/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/linked-list/CMakeLists.txt
+++ b/exercises/practice/linked-list/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/matrix/CMakeLists.txt
+++ b/exercises/practice/matrix/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/perfect-numbers/CMakeLists.txt
+++ b/exercises/practice/perfect-numbers/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/rational-numbers/CMakeLists.txt
+++ b/exercises/practice/rational-numbers/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/saddle-points/CMakeLists.txt
+++ b/exercises/practice/saddle-points/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/yacht/CMakeLists.txt
+++ b/exercises/practice/yacht/CMakeLists.txt
@@ -16,13 +16,13 @@ string(REPLACE "-" "_" file ${exercise})
 # Activate Fortran compiler warnings
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
   if(WIN32)
-    set (CCMAKE_Fortran_FLAG ${CCMAKE_Fortran_FLAGS} "/warn:all")
+    add_compile_options(/warn:all)
   else()
-    set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-warn all")
+    add_compile_options(-warn all)
   endif()
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
-  set (CMAKE_Fortran_FLAGS ${CCMAKE_Fortran_FLAGS} "-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace")
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
 endif()
 
 # Configure to run all the tests?


### PR DESCRIPTION
- Ref: https://cmake.org/cmake/help/latest/command/add_compile_options.html Also fixes existing typos ("CCMAKE_Fortran_Flag", "CCMAKE_Fortran_Flags")
- Do not use CMAKE_Fortran_FLAGS which prevents FFLAGS from working (ref: https://cmake.org/cmake/help/latest/envvar/FFLAGS.html)