### PR TITLE
Add Exercise:  Protein Translation

### DIFF
--- a/config.json
+++ b/config.json
@@ -477,6 +477,18 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8
+      },
+      {
+        "slug": "protein-translation",
+        "name": "Protein Translation",
+        "uuid": "3d2ba0a1-2a2a-4e1f-89e8-c5add9ddceef",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "lists",
+          "strings"
+        ]
       }
     ]
   }

--- a/exercises/practice/protein-translation/.docs/instructions.md
+++ b/exercises/practice/protein-translation/.docs/instructions.md
@@ -1,0 +1,45 @@
+# Instructions
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
+If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+| Codon              | Protein       |
+| :----------------- | :------------ |
+| AUG                | Methionine    |
+| UUU, UUC           | Phenylalanine |
+| UUA, UUG           | Leucine       |
+| UCU, UCC, UCA, UCG | Serine        |
+| UAU, UAC           | Tyrosine      |
+| UGU, UGC           | Cysteine      |
+| UGG                | Tryptophan    |
+| UAA, UAG, UGA      | STOP          |
+
+Learn more about [protein translation on Wikipedia][protein-translation].
+
+[protein-translation]: https://en.wikipedia.org/wiki/Translation_(biology)

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,0 +1,16 @@
+{
+  "authors": ["D3usXMachina"],
+  "files": {
+    "solution": [
+      "protein_translation.f90"
+    ],
+    "test": [
+      "protein_translation_test.f90"
+    ],
+    "example": [
+      ".meta/example.f90"
+    ]
+  },
+  "blurb": "Translate RNA sequences into proteins.",
+  "source": "Tyler Long"
+}

--- a/exercises/practice/protein-translation/.meta/example.f90
+++ b/exercises/practice/protein-translation/.meta/example.f90
@@ -1,0 +1,63 @@
+module protein_translation
+  implicit none
+
+  character(len=13), parameter, private :: protein_names(7) = [&
+    "Methionine   ", &
+    "Phenylalanine", &
+    "Leucine      ", &
+    "Serine       ", &
+    "Tyrosine     ", &
+    "Cysteine     ", &
+    "Tryptophan   " &
+    ]
+
+contains
+
+  function proteins(rna) result(names)
+    character(len=*), intent(in) :: rna
+    integer, allocatable :: protein_ids(:)
+    character(len=13), allocatable :: names(:)
+    integer :: i, n_protein, max_n_proteins
+    
+    max_n_proteins = len(rna)/3
+    allocate(protein_ids(0:max_n_proteins-1))
+
+    n_protein = 0
+    do i = 1, len(rna), 3
+      if (i + 2 > len(rna)) then
+        n_protein = 0
+        exit ! Invalid codon
+      end if
+      select case (rna(i:i+2))
+        case ("AUG") 
+          protein_ids(n_protein+1) = 1
+        case ("UUU", "UUC")
+          protein_ids(n_protein+1) = 2
+        case ("UUA", "UUG")
+          protein_ids(n_protein+1) = 3
+        case ("UCU", "UCC", "UCA", "UCG")
+          protein_ids(n_protein+1) = 4
+        case ("UAU", "UAC")
+          protein_ids(n_protein+1) = 5
+        case ("UGU", "UGC")
+          protein_ids(n_protein+1) = 6
+        case ("UGG")
+          protein_ids(n_protein+1) = 7
+        case ("UAA", "UAG", "UGA")
+          exit ! stop codon
+        case default
+          n_protein = 0
+          exit ! invalid codon
+      end select
+      n_protein = n_protein + 1
+    end do
+
+    allocate(names(n_protein))
+    do i = 1, n_protein
+      names(i) = protein_names(protein_ids(i))
+    end do
+
+  end function proteins
+
+end module protein_translation
+

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -1,0 +1,100 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
+description = "Empty RNA sequence results in no proteins"
+
+[96d3d44f-34a2-4db4-84cd-fff523e069be]
+description = "Methionine RNA sequence"
+
+[1b4c56d8-d69f-44eb-be0e-7b17546143d9]
+description = "Phenylalanine RNA sequence 1"
+
+[81b53646-bd57-4732-b2cb-6b1880e36d11]
+description = "Phenylalanine RNA sequence 2"
+
+[42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
+description = "Leucine RNA sequence 1"
+
+[ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
+description = "Leucine RNA sequence 2"
+
+[8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
+description = "Serine RNA sequence 1"
+
+[5c3fa5da-4268-44e5-9f4b-f016ccf90131]
+description = "Serine RNA sequence 2"
+
+[00579891-b594-42b4-96dc-7ff8bf519606]
+description = "Serine RNA sequence 3"
+
+[08c61c3b-fa34-4950-8c4a-133945570ef6]
+description = "Serine RNA sequence 4"
+
+[54e1e7d8-63c0-456d-91d2-062c72f8eef5]
+description = "Tyrosine RNA sequence 1"
+
+[47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
+description = "Tyrosine RNA sequence 2"
+
+[3a691829-fe72-43a7-8c8e-1bd083163f72]
+description = "Cysteine RNA sequence 1"
+
+[1b6f8a26-ca2f-43b8-8262-3ee446021767]
+description = "Cysteine RNA sequence 2"
+
+[1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
+description = "Tryptophan RNA sequence"
+
+[e547af0b-aeab-49c7-9f13-801773a73557]
+description = "STOP codon RNA sequence 1"
+
+[67640947-ff02-4f23-a2ef-816f8a2ba72e]
+description = "STOP codon RNA sequence 2"
+
+[9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
+description = "STOP codon RNA sequence 3"
+
+[f4d9d8ee-00a8-47bf-a1e3-1641d4428e54]
+description = "Sequence of two protein codons translates into proteins"
+
+[dd22eef3-b4f1-4ad6-bb0b-27093c090a9d]
+description = "Sequence of two different protein codons translates into proteins"
+
+[d0f295df-fb70-425c-946c-ec2ec185388e]
+description = "Translate RNA strand into correct protein list"
+
+[e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
+description = "Translation stops if STOP codon at beginning of sequence"
+
+[5358a20b-6f4c-4893-bce4-f929001710f3]
+description = "Translation stops if STOP codon at end of two-codon sequence"
+
+[ba16703a-1a55-482f-bb07-b21eef5093a3]
+description = "Translation stops if STOP codon at end of three-codon sequence"
+
+[4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
+description = "Translation stops if STOP codon in middle of three-codon sequence"
+
+[2c2a2a60-401f-4a80-b977-e0715b23b93d]
+description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -86,15 +86,3 @@ description = "Translation stops if STOP codon in middle of three-codon sequence
 
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
-
-[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
-description = "Non-existing codon can't translate"
-
-[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
-description = "Unknown amino acids, not part of a codon, can't translate"
-
-[9d73899f-e68e-4291-b1e2-7bf87c00f024]
-description = "Incomplete RNA sequence can't translate"
-
-[43945cf7-9968-402d-ab9f-b8a28750b050]
-description = "Incomplete RNA sequence can translate if valid until a STOP codon"

--- a/exercises/practice/protein-translation/CMakeLists.txt
+++ b/exercises/practice/protein-translation/CMakeLists.txt
@@ -1,0 +1,71 @@
+# Get the exercise name from the current directory
+get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+
+# Basic CMake project
+cmake_minimum_required(VERSION 3.0.0)
+
+# Name the project after the exercise
+project(${exercise} Fortran)
+
+# set debug build default
+set(CMAKE_BUILD_TYPE Debug)
+
+# Get a source filename from the exercise name by replacing -'s with _'s
+string(REPLACE "-" "_" file ${exercise})
+
+# Activate Fortran compiler warnings
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel") # Intel fortran
+  if(WIN32)
+    add_compile_options(/warn:all)
+  else()
+    add_compile_options(-warn all)
+  endif()
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU") # GFortran
+  add_compile_options(-std=f2008 -W -Wall -Wextra -pedantic -fbacktrace)
+endif()
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
+    set(exercise_f90 ${file}_build_all.f90)
+else()
+    # if building in exercise folder add testlib
+    set(testlib_path ${CMAKE_CURRENT_SOURCE_DIR}/testlib)
+    if (NOT EXISTS ${testlib_path})
+      if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../testlib) # in git repo locally?
+        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../../testlib DESTINATION  ${CMAKE_CURRENT_SOURCE_DIR} PATTERN *)
+      else() # get from git with http
+        message("Downloading testlib from https://raw.githubusercontent.com/exercism/fortran/master")
+        file(MAKE_DIRECTORY ${testlib_path} )
+        file(DOWNLOAD https://raw.githubusercontent.com/exercism/fortran/master/testlib/TesterMain.f90 ${testlib_path}/TesterMain.f90 SHOW_PROGRESS)
+        file(DOWNLOAD https://raw.githubusercontent.com/exercism/fortran/master/testlib/CMakeLists.txt ${testlib_path}/CMakeLists.txt SHOW_PROGRESS)
+      endif()
+    endif()
+    # add lib to build
+    add_subdirectory(testlib)
+    include_directories(testlib ${CMAKE_CURRENT_BINARY_DIR}/testlib)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.f90)
+        set(exercise_f90 ${file}.f90)
+    endif()
+endif()
+
+# Get test_files if exercise needs it
+file(GLOB test_files test_files/*.*)
+foreach(test_file ${test_files})
+    message("Copying ${test_file} to binary directory for example ${file}")
+    configure_file(${test_file} . COPYONLY)
+endforeach()
+
+# Build executable from sources and headers
+add_executable(${exercise} ${exercise_f90} ${file}_test.f90  )
+
+target_link_libraries(${exercise} TesterMain)
+
+include(CTest)
+
+add_test (${exercise}_test ${exercise} )
+
+# Run the tests on every build
+#add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})
+

--- a/exercises/practice/protein-translation/protein_translation.f90
+++ b/exercises/practice/protein-translation/protein_translation.f90
@@ -1,0 +1,14 @@
+module protein_translation
+  implicit none
+
+contains
+
+  function proteins(rna) result(names)
+    character(len=*), intent(in) :: rna
+    character(len=13), allocatable :: names(:)
+
+    names = [character(len=13) :: rna] ! Replace this line in your implementation
+  end function proteins
+
+end module protein_translation
+

--- a/exercises/practice/protein-translation/protein_translation_test.f90
+++ b/exercises/practice/protein-translation/protein_translation_test.f90
@@ -92,24 +92,6 @@ program protein_translation_test_main
     proteins("UGGUGUUAUUAAUGGUUU"), &
     "Translation stops if STOP codon in middle of six-codon sequence")
 
-  ! Test 27: Non-existing codon can't translate
-  ! ERROR: Invalid codon
-  call assert_equal([character(len=13) :: ], proteins("AAA"), "Non-existing codon can't translate")
-
-  ! Test 28: Unknown amino acids, not part of a codon, can't translate
-  ! ERROR: Invalid codon
-  call assert_equal([character(len=13) :: ], proteins("XYZ"), &
-    "Unknown amino acids, not part of a codon, can't translate")
-
-  ! Test 29: Incomplete RNA sequence can't translate
-  ! ERROR: Invalid codon
-  call assert_equal([character(len=13) :: ], proteins("AUGU"), &
-    "Incomplete RNA sequence can't translate")
-
-  ! Test 30: Incomplete RNA sequence can translate if valid until a STOP codon
-  call assert_equal([character(len=13) :: 'Phenylalanine', 'Phenylalanine'], proteins("UUCUUCUAAUGGU"), &
-    "Incomplete RNA sequence can translate if valid until a STOP codon")
-
   call test_report()
 
 end program protein_translation_test_main

--- a/exercises/practice/protein-translation/protein_translation_test.f90
+++ b/exercises/practice/protein-translation/protein_translation_test.f90
@@ -1,0 +1,116 @@
+! The tests were created from https://github.com/exercism/problem-specifications/blob/main/exercises/protein-translation/canonical-data.json
+
+program protein_translation_test_main
+  use TesterMain
+  use protein_translation
+  implicit none
+
+  ! Test 1: Empty RNA sequence results in no proteins
+  call assert_equal([character(len=13) ::], proteins(""), "Empty RNA sequence results in no proteins")
+
+  ! Test 2: Methionine RNA sequence
+  call assert_equal([character(len=13) :: 'Methionine'], proteins("AUG"), "Methionine RNA sequence")
+
+  ! Test 3: Phenylalanine RNA sequence 1
+  call assert_equal([character(len=13) :: 'Phenylalanine'], proteins("UUU"), "Phenylalanine RNA sequence 1")
+
+  ! Test 4: Phenylalanine RNA sequence 2
+  call assert_equal([character(len=13) :: 'Phenylalanine'], proteins("UUC"), "Phenylalanine RNA sequence 1")
+
+  ! Test 5: Leucine RNA sequence 1
+  call assert_equal([character(len=13) :: 'Leucine'], proteins("UUA"), "Leucine RNA sequence 1")
+
+  ! Test 6: Leucine RNA sequence 2
+  call assert_equal([character(len=13) :: 'Leucine'], proteins("UUG"), "Leucine RNA sequence 1")
+
+  ! Test 7: Serine RNA sequence 1
+  call assert_equal([character(len=13) :: 'Serine'], proteins("UCU"), "Serine RNA sequence 1")
+
+  ! Test 8: Serine RNA sequence 2
+  call assert_equal([character(len=13) :: 'Serine'], proteins("UCC"), "Serine RNA sequence 2")
+
+  ! Test 9: Serine RNA sequence 3
+  call assert_equal([character(len=13) :: 'Serine'], proteins("UCA"), "Serine RNA sequence 3")
+
+  ! Test 10: Serine RNA sequence 4
+  call assert_equal([character(len=13) :: 'Serine'], proteins("UCG"), "Serine RNA sequence 4")
+
+  ! Test 11: Tyrosine RNA sequence 1
+  call assert_equal([character(len=13) :: 'Tyrosine'], proteins("UAU"), "Tyrosine RNA sequence 1")
+
+  ! Test 12: Tyrosine RNA sequence 2
+  call assert_equal([character(len=13) :: 'Tyrosine'], proteins("UAC"), "Tyrosine RNA sequence 2")
+
+  ! Test 13: Cysteine RNA sequence 1
+  call assert_equal([character(len=13) :: 'Cysteine'], proteins("UGU"), "Cysteine RNA sequence 1")
+
+  ! Test 14: Cysteine RNA sequence 2
+  call assert_equal([character(len=13) :: 'Cysteine'], proteins("UGC"), "Cysteine RNA sequence 2")
+
+  ! Test 15: Tryptophan RNA sequence
+  call assert_equal([character(len=13) :: 'Tryptophan'], proteins("UGG"), "Tryptophan RNA sequence")
+
+  ! Test 16: STOP codon RNA sequence 1
+  call assert_equal([character(len=13) :: ], proteins("UAA"), "STOP codon RNA sequence 1")
+
+  ! Test 17: STOP codon RNA sequence 2
+  call assert_equal([character(len=13) :: ], proteins("UAG"), "STOP codon RNA sequence 2")
+
+  ! Test 18: STOP codon RNA sequence 3
+  call assert_equal([character(len=13) :: ], proteins("UGA"), "STOP codon RNA sequence 3")
+
+  ! Test 19: Sequence of two protein codons translates into proteins
+  call assert_equal([character(len=13) :: 'Phenylalanine', 'Phenylalanine'], proteins("UUUUUU"), &
+    "Sequence of two protein codons translates into proteins")
+
+  ! Test 20: Sequence of two different protein codons translates into proteins
+  call assert_equal([character(len=13) :: 'Leucine', 'Leucine'], proteins("UUAUUG"), &
+    "Sequence of two different protein codons translates into proteins")
+
+  ! Test 21: Translate RNA strand into correct protein list
+  call assert_equal([character(len=13) :: 'Methionine', 'Phenylalanine', 'Tryptophan'], &
+    proteins("AUGUUUUGG"), "Translate RNA strand into correct protein list")
+
+  ! Test 22: Translation stops if STOP codon at beginning of sequence
+  call assert_equal([character(len=13) :: ], proteins("UAGUGG"), &
+    "Translation stops if STOP codon at beginning of sequence")
+
+  ! Test 23: Translation stops if STOP codon at end of two-codon sequence
+  call assert_equal([character(len=13) :: 'Tryptophan'], proteins("UGGUAG"), &
+    "Translation stops if STOP codon at end of two-codon sequence")
+
+  ! Test 24: Translation stops if STOP codon at end of three-codon sequence
+  call assert_equal([character(len=13) :: 'Methionine', 'Phenylalanine'], proteins("AUGUUUUAA"), &
+    "Translation stops if STOP codon at end of three-codon sequence")
+
+  ! Test 25: Translation stops if STOP codon in middle of three-codon sequence
+  call assert_equal([character(len=13) :: 'Tryptophan'], proteins("UGGUAGUGG"), &
+    "Translation stops if STOP codon in middle of three-codon sequence")
+
+  ! Test 26: Translation stops if STOP codon in middle of six-codon sequence
+  call assert_equal([character(len=13) :: 'Tryptophan', 'Cysteine', 'Tyrosine'], &
+    proteins("UGGUGUUAUUAAUGGUUU"), &
+    "Translation stops if STOP codon in middle of six-codon sequence")
+
+  ! Test 27: Non-existing codon can't translate
+  ! ERROR: Invalid codon
+  call assert_equal([character(len=13) :: ], proteins("AAA"), "Non-existing codon can't translate")
+
+  ! Test 28: Unknown amino acids, not part of a codon, can't translate
+  ! ERROR: Invalid codon
+  call assert_equal([character(len=13) :: ], proteins("XYZ"), &
+    "Unknown amino acids, not part of a codon, can't translate")
+
+  ! Test 29: Incomplete RNA sequence can't translate
+  ! ERROR: Invalid codon
+  call assert_equal([character(len=13) :: ], proteins("AUGU"), &
+    "Incomplete RNA sequence can't translate")
+
+  ! Test 30: Incomplete RNA sequence can translate if valid until a STOP codon
+  call assert_equal([character(len=13) :: 'Phenylalanine', 'Phenylalanine'], proteins("UUCUUCUAAUGGU"), &
+    "Incomplete RNA sequence can translate if valid until a STOP codon")
+
+  call test_report()
+
+end program protein_translation_test_main
+


### PR DESCRIPTION
Adds the protein translation exercise (discussed [here](https://forum.exercism.org/t/fortran-protein-translation-exercise/9452/4)).

Also adds the required `assert_equal` for arrays of strings to the testlib (discussed [here](https://forum.exercism.org/t/assert-equal-for-arrays-of-strings-in-the-fortran-track-test-library/9451)).