### PR TITLE
fix: update macOs workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             runs-on: ubuntu-22.04
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-14
 
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             runs-on: ubuntu-22.04
 
           - os: macos
-            runs-on: macos-14
+            runs-on: macos-13
 
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 13.
(arm architecture from macOS-14 is probably not compatible with our current setup)

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612