### PR TITLE
Sync tests with problem specs

### DIFF
--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -86,3 +86,23 @@ description = "Translation stops if STOP codon in middle of three-codon sequence
 
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[f6f92714-769f-4187-9524-e353e8a41a80]
+description = "Sequence of two non-STOP codons does not translate to a STOP codon"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+include = false
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+include = false
+reimplements = "1e75ea2a-f907-4994-ae5c-118632a1cb0f"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+include = false
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"
+include = false

--- a/exercises/practice/protein-translation/protein_translation_test.f90
+++ b/exercises/practice/protein-translation/protein_translation_test.f90
@@ -92,7 +92,11 @@ program protein_translation_test_main
     proteins("UGGUGUUAUUAAUGGUUU"), &
     "Translation stops if STOP codon in middle of six-codon sequence")
 
+  ! Test 27: Sequence of two non-STOP codons does not translate to a STOP codon
+  call assert_equal([character(len=13) :: 'Methionine', 'Methionine'], &
+    proteins("AUGAUG"), &
+    "Sequence of two non-STOP codons does not translate to a STOP codon")
+
   call test_report()
 
 end program protein_translation_test_main
-

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -26,3 +26,15 @@ description = "a palindrome"
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+include = false
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+include = false
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"
+include = false

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -84,5 +84,8 @@ description = "3000 is MMM"
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
 
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
+
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/roman_numerals_test.f90
+++ b/exercises/practice/roman-numerals/roman_numerals_test.f90
@@ -80,10 +80,12 @@ program roman_numerals_test_main
   ! Test 25: 3001 is MMMI
   call assert_equal("MMMI", roman(3001), "3001 is MMMI")
 
-  ! Test 26: 3999 is MMMCMXCIX
+  ! Test 26: 3888 is MMMDCCCLXXXVIII
+  call assert_equal("MMMDCCCLXXXVIII", roman(3888), "3888 is MMMDCCCLXXXVIII")
+
+  ! Test 27: 3999 is MMMCMXCIX
   call assert_equal("MMMCMXCIX", roman(3999), "3999 is MMMCMXCIX")
 
   call test_report()
 
 end program
-


### PR DESCRIPTION
[no important files changed]

#### Protein translation

Explicitly skipped four missing test cases as per #245 and [forum discussion](https://forum.exercism.org/t/fortran-protein-translation-exercise/9452).

Added one missing test case. All published solutions pass the additional test.

#### Reverse string

Explicitly skipped test cases that depend on Unicode support.

#### Roman numerals

Added one missing test case. This is not expected to break any existing solutions, because the stub file specifies the required output length.
