### PR TITLE
Matrix exercise: Tests 1 and 5 (one number matrix) uncommented, changed.

### DIFF
--- a/exercises/practice/matrix/matrix_test.f90
+++ b/exercises/practice/matrix/matrix_test.f90
@@ -6,7 +6,7 @@ program matrix_test_main
    implicit none
 
    ! Test 1: extract row from one number matrix
-   !!call assert_equal_int_arr(1, row(1, 1), "extract row from one number matrix")
+   call assert_equal_int_arr((/1/), row( (/"1"/), (/1, 1/), 1), "extract row from one number matrix")
    ! Test 2: can extract row
    call assert_equal((/3, 4/), row( (/"1, 2", "3, 4"/), (/ 2, 2 /), 2), "can extract row")
 
@@ -21,7 +21,7 @@ program matrix_test_main
    &   "8, 7, 6"/), (/ 4, 3 /), 4), &
    &  "can extract row from non-square matrix with no corresponding column")
    ! Test 5: extract column from one number matrix
-   !!call assert_equal_int_arr(1, column(1, 1), "extract column from one number matrix")
+   call assert_equal_int_arr((/1/), column( (/"1"/), (/1, 1/), 1), "extract column from one number matrix")
    ! Test 6: can extract column
    call assert_equal((/3, 6, 9/), column( &
    & (/"1, 2, 3", &
@@ -32,13 +32,13 @@ program matrix_test_main
    call assert_equal((/4, 8, 6/), column( &
    & (/"1, 2, 3, 4", &
    &   "5, 6, 7, 8", &
-   &   "9, 8, 7, 6"/), (/3,4/), 4), &
+   &   "9, 8, 7, 6"/), (/3, 4/), 4), &
    & "can extract column from non-square matrix with no corresponding row")
    ! Test 8: extract column where numbers have different widths
    call assert_equal((/1903, 3, 479/), column( &
    &  (/"89, 1903, 3", &
    &    "18, 3, 1   ", &
-   &    "9, 479, 800"/), (/3,3/), 2), &
+   &    "9, 479, 800"/), (/3, 3/), 2), &
    & "extract column where numbers have different widths")
 
    call test_report()


### PR DESCRIPTION
Matrix exercise tests 1 and 5 were commented out.
This causes confusion when numbering in ctest output does not match numbering in file comments.
I uncommented the tests and corrected them,
```
call assert_equal_int_arr((/1/), row( (/"1"/), (/1, 1/), 1), "extract row from one number matrix")
```
as I understand it the matrix is [[1]] with dimensions 1 x 1 and we are getting row 1 or column 1, which should equal [1] .
"Tested" by running the test with my so-far-passing fortran solution to the exercise.  Now 8 passing tests are indicated in line with other languages.