### PR TITLE
Bump the min cmake version used by the fortran-test-runner

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 4.1.0)
 
 # Name the project after the exercise
 project(${exercise} Fortran)

--- a/testlib/CMakeLists.txt
+++ b/testlib/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 4.1.0)
 
 add_library(TesterMain STATIC TesterMain.f90 )


### PR DESCRIPTION
This is intended to be used by https://github.com/exercism/fortran-test-runner/pull/69