### PR TITLE
[protein-translation] Fix an off-by-one in the example

### DIFF
--- a/exercises/practice/protein-translation/.meta/example.f90
+++ b/exercises/practice/protein-translation/.meta/example.f90
@@ -20,7 +20,7 @@ contains
     integer :: i, n_protein, max_n_proteins
     
     max_n_proteins = len(rna)/3
-    allocate(protein_ids(0:max_n_proteins-1))
+    allocate(protein_ids(max_n_proteins))
 
     n_protein = 0
     do i = 1, len(rna), 3


### PR DESCRIPTION
This example fails with newer versions of Alpine/gfortran. This is a prereq for https://github.com/exercism/fortran-test-runner/pull/69