### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Track-specific instructions
 
 In the Fortran version of this exercise, a queen's position is represented using an array of **one**-indexed coordinates. The white queen in the example above is at position `[4, 3]` and the black queen is at `[7, 6]`.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.